### PR TITLE
102_color_cube_vulkan: Fix CMakeLists.txt for DXC

### DIFF
--- a/projects/geometry/102_color_cube_vulkan/CMakeLists.txt
+++ b/projects/geometry/102_color_cube_vulkan/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(
     PUBLIC glfw
            glslang
            SPIRV
+		   dxcompiler
 )
 
 if(WIN32)


### PR DESCRIPTION
Since we added DXC to the vk_renderer.cpp, this fix just adds it to the CMakeLists.txt for this project so that it doesn't fail to compile.