### PR TITLE
Fix MultiSample Validation Layer Error

### DIFF
--- a/projects/common/vk_renderer.cpp
+++ b/projects/common/vk_renderer.cpp
@@ -1626,10 +1626,10 @@ VkResult CreateDrawVertexColorPipeline(
     vertex_attribute_desc[0].format                            = VK_FORMAT_R32G32B32_SFLOAT;
     vertex_attribute_desc[0].offset                            = 0;
 
-   vertex_attribute_desc[1].location = 1;
-   vertex_attribute_desc[1].binding  = isInterleavedAttrs ? 0 : 1;
-   vertex_attribute_desc[1].format   = VK_FORMAT_R32G32B32_SFLOAT;
-   vertex_attribute_desc[1].offset   = isInterleavedAttrs ? 12 : 0;
+    vertex_attribute_desc[1].location = 1;
+    vertex_attribute_desc[1].binding  = isInterleavedAttrs ? 0 : 1;
+    vertex_attribute_desc[1].format   = VK_FORMAT_R32G32B32_SFLOAT;
+    vertex_attribute_desc[1].offset   = isInterleavedAttrs ? 12 : 0;
 
     VkPipelineVertexInputStateCreateInfo vertex_input_state = {VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
     vertex_input_state.vertexBindingDescriptionCount        = 2;
@@ -1695,6 +1695,9 @@ VkResult CreateDrawVertexColorPipeline(
     dynamic_state.dynamicStateCount                = 2;
     dynamic_state.pDynamicStates                   = dynamic_states;
 
+    VkPipelineMultisampleStateCreateInfo pipelineMultiStateCreateInfo = {VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
+    pipelineMultiStateCreateInfo.rasterizationSamples                 = VK_SAMPLE_COUNT_1_BIT;
+
     VkGraphicsPipelineCreateInfo pipeline_info = {VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
     pipeline_info.pNext                        = &pipeline_rendering_create_info;
     pipeline_info.stageCount                   = 2;
@@ -1703,6 +1706,7 @@ VkResult CreateDrawVertexColorPipeline(
     pipeline_info.pInputAssemblyState          = &input_assembly;
     pipeline_info.pViewportState               = &viewport_state;
     pipeline_info.pRasterizationState          = &rasterization_state;
+    pipeline_info.pMultisampleState            = &pipelineMultiStateCreateInfo;
     pipeline_info.pDepthStencilState           = &depth_stencil_state;
     pipeline_info.pColorBlendState             = &color_blend_state;
     pipeline_info.pDynamicState                = &dynamic_state;
@@ -1736,156 +1740,158 @@ HRESULT CreateDrawNormalPipeline(
    const char*          vsEntryPoint,
    const char*          fsEntryPoint)
 {
-   VkFormat                      rtv_format                     = GREX_DEFAULT_RTV_FORMAT;
-   VkPipelineRenderingCreateInfo pipeline_rendering_create_info = { VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO };
-   pipeline_rendering_create_info.colorAttachmentCount          = 1;
-   pipeline_rendering_create_info.pColorAttachmentFormats       = &rtv_format;
-   pipeline_rendering_create_info.depthAttachmentFormat         = GREX_DEFAULT_DSV_FORMAT;
+    VkFormat                      rtv_format                     = GREX_DEFAULT_RTV_FORMAT;
+    VkPipelineRenderingCreateInfo pipeline_rendering_create_info = {VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO};
+    pipeline_rendering_create_info.colorAttachmentCount          = 1;
+    pipeline_rendering_create_info.pColorAttachmentFormats       = &rtv_format;
+    pipeline_rendering_create_info.depthAttachmentFormat         = GREX_DEFAULT_DSV_FORMAT;
 
-   VkPipelineShaderStageCreateInfo shader_stages[2] = { VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO };
-   shader_stages[0].stage                           = VK_SHADER_STAGE_VERTEX_BIT;
-   shader_stages[0].module                          = vsShaderModule;
-   shader_stages[0].pName                           = vsEntryPoint;
-   shader_stages[1].sType                           = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-   shader_stages[1].stage                           = VK_SHADER_STAGE_FRAGMENT_BIT;
-   shader_stages[1].module                          = fsShaderModule;
-   shader_stages[1].pName                           = fsEntryPoint;
+    VkPipelineShaderStageCreateInfo shader_stages[2] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
+    shader_stages[0].stage                           = VK_SHADER_STAGE_VERTEX_BIT;
+    shader_stages[0].module                          = vsShaderModule;
+    shader_stages[0].pName                           = vsEntryPoint;
+    shader_stages[1].sType                           = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    shader_stages[1].stage                           = VK_SHADER_STAGE_FRAGMENT_BIT;
+    shader_stages[1].module                          = fsShaderModule;
+    shader_stages[1].pName                           = fsEntryPoint;
 
-   VkVertexInputBindingDescription vertex_binding_desc[4] = {};
-   vertex_binding_desc[0].binding   = 0;
-   vertex_binding_desc[0].stride    = 12;
-   vertex_binding_desc[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+    VkVertexInputBindingDescription vertex_binding_desc[4] = {};
+    vertex_binding_desc[0].binding                         = 0;
+    vertex_binding_desc[0].stride                          = 12;
+    vertex_binding_desc[0].inputRate                       = VK_VERTEX_INPUT_RATE_VERTEX;
 
-   vertex_binding_desc[1].binding   = 1;
-   vertex_binding_desc[1].stride    = 12;
-   vertex_binding_desc[1].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+    vertex_binding_desc[1].binding   = 1;
+    vertex_binding_desc[1].stride    = 12;
+    vertex_binding_desc[1].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
 
-   if (enableTangents)
-   {
-      vertex_binding_desc[2].binding   = 2;
-      vertex_binding_desc[2].stride    = 12;
-      vertex_binding_desc[2].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+    if (enableTangents) {
+        vertex_binding_desc[2].binding   = 2;
+        vertex_binding_desc[2].stride    = 12;
+        vertex_binding_desc[2].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
 
-      vertex_binding_desc[3].binding   = 3;
-      vertex_binding_desc[3].stride    = 12;
-      vertex_binding_desc[3].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
-   }
+        vertex_binding_desc[3].binding   = 3;
+        vertex_binding_desc[3].stride    = 12;
+        vertex_binding_desc[3].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+    }
 
-   VkVertexInputAttributeDescription vertex_attribute_desc[4] = {};
-   vertex_attribute_desc[0].location                          = 0;
-   vertex_attribute_desc[0].binding                           = 0;
-   vertex_attribute_desc[0].format                            = VK_FORMAT_R32G32B32_SFLOAT;
-   vertex_attribute_desc[0].offset                            = 0;
+    VkVertexInputAttributeDescription vertex_attribute_desc[4] = {};
+    vertex_attribute_desc[0].location                          = 0;
+    vertex_attribute_desc[0].binding                           = 0;
+    vertex_attribute_desc[0].format                            = VK_FORMAT_R32G32B32_SFLOAT;
+    vertex_attribute_desc[0].offset                            = 0;
 
-   vertex_attribute_desc[1].location = 1;
-   vertex_attribute_desc[1].binding  = 1;
-   vertex_attribute_desc[1].format   = VK_FORMAT_R32G32B32_SFLOAT;
-   vertex_attribute_desc[1].offset   = 0;
+    vertex_attribute_desc[1].location = 1;
+    vertex_attribute_desc[1].binding  = 1;
+    vertex_attribute_desc[1].format   = VK_FORMAT_R32G32B32_SFLOAT;
+    vertex_attribute_desc[1].offset   = 0;
 
-   if (enableTangents)
-   {
-      vertex_attribute_desc[2].location = 2;
-      vertex_attribute_desc[2].binding  = 2;
-      vertex_attribute_desc[2].format   = VK_FORMAT_R32G32B32_SFLOAT;
-      vertex_attribute_desc[2].offset   = 0;
+    if (enableTangents) {
+        vertex_attribute_desc[2].location = 2;
+        vertex_attribute_desc[2].binding  = 2;
+        vertex_attribute_desc[2].format   = VK_FORMAT_R32G32B32_SFLOAT;
+        vertex_attribute_desc[2].offset   = 0;
 
-      vertex_attribute_desc[3].location = 3;
-      vertex_attribute_desc[3].binding  = 3;
-      vertex_attribute_desc[3].format   = VK_FORMAT_R32G32B32_SFLOAT;
-      vertex_attribute_desc[3].offset   = 0;
-   }
+        vertex_attribute_desc[3].location = 3;
+        vertex_attribute_desc[3].binding  = 3;
+        vertex_attribute_desc[3].format   = VK_FORMAT_R32G32B32_SFLOAT;
+        vertex_attribute_desc[3].offset   = 0;
+    }
 
-   VkPipelineVertexInputStateCreateInfo vertex_input_state = { VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO };
-   vertex_input_state.vertexBindingDescriptionCount        = enableTangents ? 4 : 2;
-   vertex_input_state.pVertexBindingDescriptions           = vertex_binding_desc;
-   vertex_input_state.vertexAttributeDescriptionCount      = enableTangents ? 4 : 2;
-   vertex_input_state.pVertexAttributeDescriptions         = vertex_attribute_desc;
+    VkPipelineVertexInputStateCreateInfo vertex_input_state = {VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
+    vertex_input_state.vertexBindingDescriptionCount        = enableTangents ? 4 : 2;
+    vertex_input_state.pVertexBindingDescriptions           = vertex_binding_desc;
+    vertex_input_state.vertexAttributeDescriptionCount      = enableTangents ? 4 : 2;
+    vertex_input_state.pVertexAttributeDescriptions         = vertex_attribute_desc;
 
-   VkPipelineInputAssemblyStateCreateInfo input_assembly = { VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO };
-   input_assembly.topology                               = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    VkPipelineInputAssemblyStateCreateInfo input_assembly = {VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
+    input_assembly.topology                               = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 
-   VkPipelineViewportStateCreateInfo viewport_state = { VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };
-   viewport_state.viewportCount                     = 1;
-   viewport_state.scissorCount                      = 1;
+    VkPipelineViewportStateCreateInfo viewport_state = {VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO};
+    viewport_state.viewportCount                     = 1;
+    viewport_state.scissorCount                      = 1;
 
-   VkPipelineRasterizationStateCreateInfo rasterization_state = { VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO };
-   rasterization_state.depthClampEnable                       = VK_FALSE;
-   rasterization_state.rasterizerDiscardEnable                = VK_FALSE;
-   rasterization_state.polygonMode                            = VK_POLYGON_MODE_FILL;
-   rasterization_state.cullMode                               = cullMode;
-   rasterization_state.frontFace                              = VK_FRONT_FACE_COUNTER_CLOCKWISE;
-   rasterization_state.depthBiasEnable                        = VK_TRUE;
-   rasterization_state.depthBiasConstantFactor                = 0.0f;
-   rasterization_state.depthBiasClamp                         = 0.0f;
-   rasterization_state.depthBiasSlopeFactor                   = 1.0f;
-   rasterization_state.lineWidth                              = 1.0f;
+    VkPipelineRasterizationStateCreateInfo rasterization_state = {VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
+    rasterization_state.depthClampEnable                       = VK_FALSE;
+    rasterization_state.rasterizerDiscardEnable                = VK_FALSE;
+    rasterization_state.polygonMode                            = VK_POLYGON_MODE_FILL;
+    rasterization_state.cullMode                               = cullMode;
+    rasterization_state.frontFace                              = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rasterization_state.depthBiasEnable                        = VK_TRUE;
+    rasterization_state.depthBiasConstantFactor                = 0.0f;
+    rasterization_state.depthBiasClamp                         = 0.0f;
+    rasterization_state.depthBiasSlopeFactor                   = 1.0f;
+    rasterization_state.lineWidth                              = 1.0f;
 
-   VkPipelineDepthStencilStateCreateInfo depth_stencil_state = { VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO };
-   depth_stencil_state.depthTestEnable                       = (dsvFormat != VK_FORMAT_UNDEFINED);
-   depth_stencil_state.depthWriteEnable                      = (dsvFormat != VK_FORMAT_UNDEFINED);
-   depth_stencil_state.depthCompareOp                        = VK_COMPARE_OP_LESS_OR_EQUAL;
-   depth_stencil_state.depthBoundsTestEnable                 = VK_FALSE;
-   depth_stencil_state.stencilTestEnable                     = VK_FALSE;
-   depth_stencil_state.front.failOp                          = VK_STENCIL_OP_KEEP;
-   depth_stencil_state.front.depthFailOp                     = VK_STENCIL_OP_KEEP;
-   depth_stencil_state.front.compareOp                       = VK_COMPARE_OP_ALWAYS;
-   depth_stencil_state.back                                  = depth_stencil_state.front;
+    VkPipelineDepthStencilStateCreateInfo depth_stencil_state = {VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
+    depth_stencil_state.depthTestEnable                       = (dsvFormat != VK_FORMAT_UNDEFINED);
+    depth_stencil_state.depthWriteEnable                      = (dsvFormat != VK_FORMAT_UNDEFINED);
+    depth_stencil_state.depthCompareOp                        = VK_COMPARE_OP_LESS_OR_EQUAL;
+    depth_stencil_state.depthBoundsTestEnable                 = VK_FALSE;
+    depth_stencil_state.stencilTestEnable                     = VK_FALSE;
+    depth_stencil_state.front.failOp                          = VK_STENCIL_OP_KEEP;
+    depth_stencil_state.front.depthFailOp                     = VK_STENCIL_OP_KEEP;
+    depth_stencil_state.front.compareOp                       = VK_COMPARE_OP_ALWAYS;
+    depth_stencil_state.back                                  = depth_stencil_state.front;
 
-   VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
-   color_blend_attachment_state.blendEnable                         = VK_FALSE;
-   color_blend_attachment_state.srcColorBlendFactor                 = VK_BLEND_FACTOR_SRC_COLOR;
-   color_blend_attachment_state.dstColorBlendFactor                 = VK_BLEND_FACTOR_ZERO;
-   color_blend_attachment_state.colorBlendOp                        = VK_BLEND_OP_ADD;
-   color_blend_attachment_state.srcAlphaBlendFactor                 = VK_BLEND_FACTOR_SRC_ALPHA;
-   color_blend_attachment_state.dstAlphaBlendFactor                 = VK_BLEND_FACTOR_ZERO;
-   color_blend_attachment_state.alphaBlendOp                        = VK_BLEND_OP_ADD;
-   color_blend_attachment_state.colorWriteMask                      = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_A_BIT;
+    VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
+    color_blend_attachment_state.blendEnable                         = VK_FALSE;
+    color_blend_attachment_state.srcColorBlendFactor                 = VK_BLEND_FACTOR_SRC_COLOR;
+    color_blend_attachment_state.dstColorBlendFactor                 = VK_BLEND_FACTOR_ZERO;
+    color_blend_attachment_state.colorBlendOp                        = VK_BLEND_OP_ADD;
+    color_blend_attachment_state.srcAlphaBlendFactor                 = VK_BLEND_FACTOR_SRC_ALPHA;
+    color_blend_attachment_state.dstAlphaBlendFactor                 = VK_BLEND_FACTOR_ZERO;
+    color_blend_attachment_state.alphaBlendOp                        = VK_BLEND_OP_ADD;
+    color_blend_attachment_state.colorWriteMask                      = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_A_BIT;
 
-   VkPipelineColorBlendStateCreateInfo color_blend_state = { VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO };
-   color_blend_state.logicOpEnable                       = VK_FALSE;
-   color_blend_state.logicOp                             = VK_LOGIC_OP_NO_OP;
-   color_blend_state.attachmentCount                     = 1;
-   color_blend_state.pAttachments                        = &color_blend_attachment_state;
-   color_blend_state.blendConstants[0]                   = 0.0f;
-   color_blend_state.blendConstants[1]                   = 0.0f;
-   color_blend_state.blendConstants[2]                   = 0.0f;
-   color_blend_state.blendConstants[3]                   = 0.0f;
+    VkPipelineColorBlendStateCreateInfo color_blend_state = {VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO};
+    color_blend_state.logicOpEnable                       = VK_FALSE;
+    color_blend_state.logicOp                             = VK_LOGIC_OP_NO_OP;
+    color_blend_state.attachmentCount                     = 1;
+    color_blend_state.pAttachments                        = &color_blend_attachment_state;
+    color_blend_state.blendConstants[0]                   = 0.0f;
+    color_blend_state.blendConstants[1]                   = 0.0f;
+    color_blend_state.blendConstants[2]                   = 0.0f;
+    color_blend_state.blendConstants[3]                   = 0.0f;
 
-   VkDynamicState dynamic_states[2] = {};
-   dynamic_states[0]                = VK_DYNAMIC_STATE_VIEWPORT;
-   dynamic_states[1]                = VK_DYNAMIC_STATE_SCISSOR;
+    VkDynamicState dynamic_states[2] = {};
+    dynamic_states[0]                = VK_DYNAMIC_STATE_VIEWPORT;
+    dynamic_states[1]                = VK_DYNAMIC_STATE_SCISSOR;
 
-   VkPipelineDynamicStateCreateInfo dynamic_state = { VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO };
-   dynamic_state.dynamicStateCount                = 2;
-   dynamic_state.pDynamicStates                   = dynamic_states;
+    VkPipelineDynamicStateCreateInfo dynamic_state = {VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
+    dynamic_state.dynamicStateCount                = 2;
+    dynamic_state.pDynamicStates                   = dynamic_states;
 
-   VkGraphicsPipelineCreateInfo pipeline_info = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO };
-   pipeline_info.flags                        = VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-   pipeline_info.pNext                        = &pipeline_rendering_create_info;
-   pipeline_info.stageCount                   = 2;
-   pipeline_info.pStages                      = shader_stages;
-   pipeline_info.pVertexInputState            = &vertex_input_state;
-   pipeline_info.pInputAssemblyState          = &input_assembly;
-   pipeline_info.pViewportState               = &viewport_state;
-   pipeline_info.pRasterizationState          = &rasterization_state;
-   pipeline_info.pDepthStencilState           = &depth_stencil_state;
-   pipeline_info.pColorBlendState             = &color_blend_state;
-   pipeline_info.pDynamicState                = &dynamic_state;
-   pipeline_info.layout                       = pipelineLayout;
-   pipeline_info.renderPass                   = VK_NULL_HANDLE;
-   pipeline_info.subpass                      = 0;
-   pipeline_info.basePipelineHandle           = VK_NULL_HANDLE;
-   pipeline_info.basePipelineIndex            = -1;
+    VkPipelineMultisampleStateCreateInfo pipelineMultiStateCreateInfo = {VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
+    pipelineMultiStateCreateInfo.rasterizationSamples                 = VK_SAMPLE_COUNT_1_BIT;
 
-   VkResult vkres = vkCreateGraphicsPipelines(
-      pRenderer->Device,
-      VK_NULL_HANDLE, // Not using a pipeline cache
-      1,
-      &pipeline_info,
-      nullptr,
-      pPipeline);
+    VkGraphicsPipelineCreateInfo pipeline_info = {VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
+    pipeline_info.flags                        = VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    pipeline_info.pNext                        = &pipeline_rendering_create_info;
+    pipeline_info.stageCount                   = 2;
+    pipeline_info.pStages                      = shader_stages;
+    pipeline_info.pVertexInputState            = &vertex_input_state;
+    pipeline_info.pInputAssemblyState          = &input_assembly;
+    pipeline_info.pViewportState               = &viewport_state;
+    pipeline_info.pRasterizationState          = &rasterization_state;
+    pipeline_info.pMultisampleState            = &pipelineMultiStateCreateInfo;
+    pipeline_info.pDepthStencilState           = &depth_stencil_state;
+    pipeline_info.pColorBlendState             = &color_blend_state;
+    pipeline_info.pDynamicState                = &dynamic_state;
+    pipeline_info.layout                       = pipelineLayout;
+    pipeline_info.renderPass                   = VK_NULL_HANDLE;
+    pipeline_info.subpass                      = 0;
+    pipeline_info.basePipelineHandle           = VK_NULL_HANDLE;
+    pipeline_info.basePipelineIndex            = -1;
 
-   return vkres;
+    VkResult vkres = vkCreateGraphicsPipelines(
+        pRenderer->Device,
+        VK_NULL_HANDLE, // Not using a pipeline cache
+        1,
+        &pipeline_info,
+        nullptr,
+        pPipeline);
+
+    return vkres;
 }
 
 HRESULT CreateDrawTexturePipeline(
@@ -1900,132 +1906,135 @@ HRESULT CreateDrawTexturePipeline(
     const char*        vsEntryPoint,
     const char*        fsEntryPoint)
 {
-   VkPipelineRenderingCreateInfo pipeline_rendering_create_info = { VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO };
-   pipeline_rendering_create_info.colorAttachmentCount          = 1;
-   pipeline_rendering_create_info.pColorAttachmentFormats       = &rtvFormat;
-   pipeline_rendering_create_info.depthAttachmentFormat         = GREX_DEFAULT_DSV_FORMAT;
+    VkPipelineRenderingCreateInfo pipeline_rendering_create_info = {VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO};
+    pipeline_rendering_create_info.colorAttachmentCount          = 1;
+    pipeline_rendering_create_info.pColorAttachmentFormats       = &rtvFormat;
+    pipeline_rendering_create_info.depthAttachmentFormat         = GREX_DEFAULT_DSV_FORMAT;
 
-   VkPipelineShaderStageCreateInfo shader_stages[2] = { VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO };
-   shader_stages[0].stage                           = VK_SHADER_STAGE_VERTEX_BIT;
-   shader_stages[0].module                          = vsShaderModule;
-   shader_stages[0].pName                           = vsEntryPoint;
-   shader_stages[1].sType                           = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-   shader_stages[1].stage                           = VK_SHADER_STAGE_FRAGMENT_BIT;
-   shader_stages[1].module                          = fsShaderModule;
-   shader_stages[1].pName                           = fsEntryPoint;
+    VkPipelineShaderStageCreateInfo shader_stages[2] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
+    shader_stages[0].stage                           = VK_SHADER_STAGE_VERTEX_BIT;
+    shader_stages[0].module                          = vsShaderModule;
+    shader_stages[0].pName                           = vsEntryPoint;
+    shader_stages[1].sType                           = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    shader_stages[1].stage                           = VK_SHADER_STAGE_FRAGMENT_BIT;
+    shader_stages[1].module                          = fsShaderModule;
+    shader_stages[1].pName                           = fsEntryPoint;
 
-   VkVertexInputBindingDescription vertex_binding_desc[2] = {};
-   vertex_binding_desc[0].binding                         = 0;
-   vertex_binding_desc[0].stride                          = 12;
-   vertex_binding_desc[0].inputRate                       = VK_VERTEX_INPUT_RATE_VERTEX;
+    VkVertexInputBindingDescription vertex_binding_desc[2] = {};
+    vertex_binding_desc[0].binding                         = 0;
+    vertex_binding_desc[0].stride                          = 12;
+    vertex_binding_desc[0].inputRate                       = VK_VERTEX_INPUT_RATE_VERTEX;
 
-   vertex_binding_desc[1].binding   = 1;
-   vertex_binding_desc[1].stride    = 8;
-   vertex_binding_desc[1].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+    vertex_binding_desc[1].binding   = 1;
+    vertex_binding_desc[1].stride    = 8;
+    vertex_binding_desc[1].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
 
-   VkVertexInputAttributeDescription vertex_attribute_desc[2] = {};
-   vertex_attribute_desc[0].location                          = 0;
-   vertex_attribute_desc[0].binding                           = 0;
-   vertex_attribute_desc[0].format                            = VK_FORMAT_R32G32B32_SFLOAT;
-   vertex_attribute_desc[0].offset                            = 0;
+    VkVertexInputAttributeDescription vertex_attribute_desc[2] = {};
+    vertex_attribute_desc[0].location                          = 0;
+    vertex_attribute_desc[0].binding                           = 0;
+    vertex_attribute_desc[0].format                            = VK_FORMAT_R32G32B32_SFLOAT;
+    vertex_attribute_desc[0].offset                            = 0;
 
-   vertex_attribute_desc[1].location = 1;
-   vertex_attribute_desc[1].binding  = 1;
-   vertex_attribute_desc[1].format   = VK_FORMAT_R32G32_SFLOAT;
-   vertex_attribute_desc[1].offset   = 0;
+    vertex_attribute_desc[1].location = 1;
+    vertex_attribute_desc[1].binding  = 1;
+    vertex_attribute_desc[1].format   = VK_FORMAT_R32G32_SFLOAT;
+    vertex_attribute_desc[1].offset   = 0;
 
-   VkPipelineVertexInputStateCreateInfo vertex_input_state = { VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO };
-   vertex_input_state.vertexBindingDescriptionCount        = 2;
-   vertex_input_state.pVertexBindingDescriptions           = vertex_binding_desc;
-   vertex_input_state.vertexAttributeDescriptionCount      = 2;
-   vertex_input_state.pVertexAttributeDescriptions         = vertex_attribute_desc;
+    VkPipelineVertexInputStateCreateInfo vertex_input_state = {VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
+    vertex_input_state.vertexBindingDescriptionCount        = 2;
+    vertex_input_state.pVertexBindingDescriptions           = vertex_binding_desc;
+    vertex_input_state.vertexAttributeDescriptionCount      = 2;
+    vertex_input_state.pVertexAttributeDescriptions         = vertex_attribute_desc;
 
-   VkPipelineInputAssemblyStateCreateInfo input_assembly = { VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO };
-   input_assembly.topology                               = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    VkPipelineInputAssemblyStateCreateInfo input_assembly = {VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
+    input_assembly.topology                               = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 
-   VkPipelineViewportStateCreateInfo viewport_state = { VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };
-   viewport_state.viewportCount                     = 1;
-   viewport_state.scissorCount                      = 1;
+    VkPipelineViewportStateCreateInfo viewport_state = {VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO};
+    viewport_state.viewportCount                     = 1;
+    viewport_state.scissorCount                      = 1;
 
-   VkPipelineRasterizationStateCreateInfo rasterization_state = { VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO };
-   rasterization_state.depthClampEnable                       = VK_FALSE;
-   rasterization_state.rasterizerDiscardEnable                = VK_FALSE;
-   rasterization_state.polygonMode                            = VK_POLYGON_MODE_FILL;
-   rasterization_state.cullMode                               = cullMode;
-   rasterization_state.frontFace                              = VK_FRONT_FACE_COUNTER_CLOCKWISE;
-   rasterization_state.depthBiasEnable                        = VK_TRUE;
-   rasterization_state.depthBiasConstantFactor                = 0.0f;
-   rasterization_state.depthBiasClamp                         = 0.0f;
-   rasterization_state.depthBiasSlopeFactor                   = 1.0f;
-   rasterization_state.lineWidth                              = 1.0f;
+    VkPipelineRasterizationStateCreateInfo rasterization_state = {VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
+    rasterization_state.depthClampEnable                       = VK_FALSE;
+    rasterization_state.rasterizerDiscardEnable                = VK_FALSE;
+    rasterization_state.polygonMode                            = VK_POLYGON_MODE_FILL;
+    rasterization_state.cullMode                               = cullMode;
+    rasterization_state.frontFace                              = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rasterization_state.depthBiasEnable                        = VK_TRUE;
+    rasterization_state.depthBiasConstantFactor                = 0.0f;
+    rasterization_state.depthBiasClamp                         = 0.0f;
+    rasterization_state.depthBiasSlopeFactor                   = 1.0f;
+    rasterization_state.lineWidth                              = 1.0f;
 
-   VkPipelineDepthStencilStateCreateInfo depth_stencil_state = { VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO };
-   depth_stencil_state.depthTestEnable                       = (dsvFormat != VK_FORMAT_UNDEFINED);
-   depth_stencil_state.depthWriteEnable                      = (dsvFormat != VK_FORMAT_UNDEFINED);
-   depth_stencil_state.depthCompareOp                        = VK_COMPARE_OP_LESS_OR_EQUAL;
-   depth_stencil_state.depthBoundsTestEnable                 = VK_FALSE;
-   depth_stencil_state.stencilTestEnable                     = VK_FALSE;
-   depth_stencil_state.front.failOp                          = VK_STENCIL_OP_KEEP;
-   depth_stencil_state.front.depthFailOp                     = VK_STENCIL_OP_KEEP;
-   depth_stencil_state.front.compareOp                       = VK_COMPARE_OP_ALWAYS;
-   depth_stencil_state.back                                  = depth_stencil_state.front;
+    VkPipelineDepthStencilStateCreateInfo depth_stencil_state = {VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
+    depth_stencil_state.depthTestEnable                       = (dsvFormat != VK_FORMAT_UNDEFINED);
+    depth_stencil_state.depthWriteEnable                      = (dsvFormat != VK_FORMAT_UNDEFINED);
+    depth_stencil_state.depthCompareOp                        = VK_COMPARE_OP_LESS_OR_EQUAL;
+    depth_stencil_state.depthBoundsTestEnable                 = VK_FALSE;
+    depth_stencil_state.stencilTestEnable                     = VK_FALSE;
+    depth_stencil_state.front.failOp                          = VK_STENCIL_OP_KEEP;
+    depth_stencil_state.front.depthFailOp                     = VK_STENCIL_OP_KEEP;
+    depth_stencil_state.front.compareOp                       = VK_COMPARE_OP_ALWAYS;
+    depth_stencil_state.back                                  = depth_stencil_state.front;
 
-   VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
-   color_blend_attachment_state.blendEnable                         = VK_FALSE;
-   color_blend_attachment_state.srcColorBlendFactor                 = VK_BLEND_FACTOR_SRC_COLOR;
-   color_blend_attachment_state.dstColorBlendFactor                 = VK_BLEND_FACTOR_ZERO;
-   color_blend_attachment_state.colorBlendOp                        = VK_BLEND_OP_ADD;
-   color_blend_attachment_state.srcAlphaBlendFactor                 = VK_BLEND_FACTOR_SRC_ALPHA;
-   color_blend_attachment_state.dstAlphaBlendFactor                 = VK_BLEND_FACTOR_ZERO;
-   color_blend_attachment_state.alphaBlendOp                        = VK_BLEND_OP_ADD;
-   color_blend_attachment_state.colorWriteMask                      = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_A_BIT;
+    VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
+    color_blend_attachment_state.blendEnable                         = VK_FALSE;
+    color_blend_attachment_state.srcColorBlendFactor                 = VK_BLEND_FACTOR_SRC_COLOR;
+    color_blend_attachment_state.dstColorBlendFactor                 = VK_BLEND_FACTOR_ZERO;
+    color_blend_attachment_state.colorBlendOp                        = VK_BLEND_OP_ADD;
+    color_blend_attachment_state.srcAlphaBlendFactor                 = VK_BLEND_FACTOR_SRC_ALPHA;
+    color_blend_attachment_state.dstAlphaBlendFactor                 = VK_BLEND_FACTOR_ZERO;
+    color_blend_attachment_state.alphaBlendOp                        = VK_BLEND_OP_ADD;
+    color_blend_attachment_state.colorWriteMask                      = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_A_BIT;
 
-   VkPipelineColorBlendStateCreateInfo color_blend_state = { VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO };
-   color_blend_state.logicOpEnable                       = VK_FALSE;
-   color_blend_state.logicOp                             = VK_LOGIC_OP_NO_OP;
-   color_blend_state.attachmentCount                     = 1;
-   color_blend_state.pAttachments                        = &color_blend_attachment_state;
-   color_blend_state.blendConstants[0]                   = 0.0f;
-   color_blend_state.blendConstants[1]                   = 0.0f;
-   color_blend_state.blendConstants[2]                   = 0.0f;
-   color_blend_state.blendConstants[3]                   = 0.0f;
+    VkPipelineColorBlendStateCreateInfo color_blend_state = {VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO};
+    color_blend_state.logicOpEnable                       = VK_FALSE;
+    color_blend_state.logicOp                             = VK_LOGIC_OP_NO_OP;
+    color_blend_state.attachmentCount                     = 1;
+    color_blend_state.pAttachments                        = &color_blend_attachment_state;
+    color_blend_state.blendConstants[0]                   = 0.0f;
+    color_blend_state.blendConstants[1]                   = 0.0f;
+    color_blend_state.blendConstants[2]                   = 0.0f;
+    color_blend_state.blendConstants[3]                   = 0.0f;
 
-   VkDynamicState dynamic_states[2] = {};
-   dynamic_states[0]                = VK_DYNAMIC_STATE_VIEWPORT;
-   dynamic_states[1]                = VK_DYNAMIC_STATE_SCISSOR;
+    VkDynamicState dynamic_states[2] = {};
+    dynamic_states[0]                = VK_DYNAMIC_STATE_VIEWPORT;
+    dynamic_states[1]                = VK_DYNAMIC_STATE_SCISSOR;
 
-   VkPipelineDynamicStateCreateInfo dynamic_state = { VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO };
-   dynamic_state.dynamicStateCount                = 2;
-   dynamic_state.pDynamicStates                   = dynamic_states;
+    VkPipelineDynamicStateCreateInfo dynamic_state = {VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
+    dynamic_state.dynamicStateCount                = 2;
+    dynamic_state.pDynamicStates                   = dynamic_states;
 
-   VkGraphicsPipelineCreateInfo pipeline_info = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO };
-   pipeline_info.flags                        = VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-   pipeline_info.pNext                        = &pipeline_rendering_create_info;
-   pipeline_info.stageCount                   = 2;
-   pipeline_info.pStages                      = shader_stages;
-   pipeline_info.pVertexInputState            = &vertex_input_state;
-   pipeline_info.pInputAssemblyState          = &input_assembly;
-   pipeline_info.pViewportState               = &viewport_state;
-   pipeline_info.pRasterizationState          = &rasterization_state;
-   pipeline_info.pDepthStencilState           = &depth_stencil_state;
-   pipeline_info.pColorBlendState             = &color_blend_state;
-   pipeline_info.pDynamicState                = &dynamic_state;
-   pipeline_info.layout                       = pipelineLayout;
-   pipeline_info.renderPass                   = VK_NULL_HANDLE;
-   pipeline_info.subpass                      = 0;
-   pipeline_info.basePipelineHandle           = VK_NULL_HANDLE;
-   pipeline_info.basePipelineIndex            = -1;
+    VkPipelineMultisampleStateCreateInfo pipelineMultiStateCreateInfo = {VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
+    pipelineMultiStateCreateInfo.rasterizationSamples                 = VK_SAMPLE_COUNT_1_BIT;
 
-   VkResult vkres = vkCreateGraphicsPipelines(
-      pRenderer->Device,
-      VK_NULL_HANDLE, // Not using a pipeline cache
-      1,
-      &pipeline_info,
-      nullptr,
-      pPipeline);
+    VkGraphicsPipelineCreateInfo pipeline_info = {VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
+    pipeline_info.flags                        = VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    pipeline_info.pNext                        = &pipeline_rendering_create_info;
+    pipeline_info.stageCount                   = 2;
+    pipeline_info.pStages                      = shader_stages;
+    pipeline_info.pVertexInputState            = &vertex_input_state;
+    pipeline_info.pInputAssemblyState          = &input_assembly;
+    pipeline_info.pViewportState               = &viewport_state;
+    pipeline_info.pRasterizationState          = &rasterization_state;
+    pipeline_info.pMultisampleState            = &pipelineMultiStateCreateInfo;
+    pipeline_info.pDepthStencilState           = &depth_stencil_state;
+    pipeline_info.pColorBlendState             = &color_blend_state;
+    pipeline_info.pDynamicState                = &dynamic_state;
+    pipeline_info.layout                       = pipelineLayout;
+    pipeline_info.renderPass                   = VK_NULL_HANDLE;
+    pipeline_info.subpass                      = 0;
+    pipeline_info.basePipelineHandle           = VK_NULL_HANDLE;
+    pipeline_info.basePipelineIndex            = -1;
 
-   return vkres;
+    VkResult vkres = vkCreateGraphicsPipelines(
+        pRenderer->Device,
+        VK_NULL_HANDLE, // Not using a pipeline cache
+        1,
+        &pipeline_info,
+        nullptr,
+        pPipeline);
 
+    return vkres;
 }
 
 HRESULT CreateDrawBasicPipeline(
@@ -2040,136 +2049,140 @@ HRESULT CreateDrawBasicPipeline(
     const char*        vsEntryPoint,
     const char*        fsEntryPoint)
 {
-   VkPipelineRenderingCreateInfo pipeline_rendering_create_info = {VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO};
-   pipeline_rendering_create_info.colorAttachmentCount          = 1;
-   pipeline_rendering_create_info.pColorAttachmentFormats       = &rtvFormat;
-   pipeline_rendering_create_info.depthAttachmentFormat         = GREX_DEFAULT_DSV_FORMAT;
+    VkPipelineRenderingCreateInfo pipeline_rendering_create_info = {VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO};
+    pipeline_rendering_create_info.colorAttachmentCount          = 1;
+    pipeline_rendering_create_info.pColorAttachmentFormats       = &rtvFormat;
+    pipeline_rendering_create_info.depthAttachmentFormat         = GREX_DEFAULT_DSV_FORMAT;
 
-   VkPipelineShaderStageCreateInfo shader_stages[2] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
-   shader_stages[0].stage                           = VK_SHADER_STAGE_VERTEX_BIT;
-   shader_stages[0].module                          = vsShaderModule;
-   shader_stages[0].pName                           = vsEntryPoint;
-   shader_stages[1].sType                           = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-   shader_stages[1].stage                           = VK_SHADER_STAGE_FRAGMENT_BIT;
-   shader_stages[1].module                          = fsShaderModule;
-   shader_stages[1].pName                           = fsEntryPoint;
+    VkPipelineShaderStageCreateInfo shader_stages[2] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
+    shader_stages[0].stage                           = VK_SHADER_STAGE_VERTEX_BIT;
+    shader_stages[0].module                          = vsShaderModule;
+    shader_stages[0].pName                           = vsEntryPoint;
+    shader_stages[1].sType                           = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    shader_stages[1].stage                           = VK_SHADER_STAGE_FRAGMENT_BIT;
+    shader_stages[1].module                          = fsShaderModule;
+    shader_stages[1].pName                           = fsEntryPoint;
 
-   VkVertexInputBindingDescription vertex_binding_desc[3] = {};
-   vertex_binding_desc[0].binding                         = 0;
-   vertex_binding_desc[0].stride                          = 12;
-   vertex_binding_desc[0].inputRate                       = VK_VERTEX_INPUT_RATE_VERTEX;
-   vertex_binding_desc[1].binding                         = 1;
-   vertex_binding_desc[1].stride                          = 8;
-   vertex_binding_desc[1].inputRate                       = VK_VERTEX_INPUT_RATE_VERTEX;
-   vertex_binding_desc[2].binding                         = 2;
-   vertex_binding_desc[2].stride                          = 12;
-   vertex_binding_desc[2].inputRate                       = VK_VERTEX_INPUT_RATE_VERTEX;
+    VkVertexInputBindingDescription vertex_binding_desc[3] = {};
+    vertex_binding_desc[0].binding                         = 0;
+    vertex_binding_desc[0].stride                          = 12;
+    vertex_binding_desc[0].inputRate                       = VK_VERTEX_INPUT_RATE_VERTEX;
+    vertex_binding_desc[1].binding                         = 1;
+    vertex_binding_desc[1].stride                          = 8;
+    vertex_binding_desc[1].inputRate                       = VK_VERTEX_INPUT_RATE_VERTEX;
+    vertex_binding_desc[2].binding                         = 2;
+    vertex_binding_desc[2].stride                          = 12;
+    vertex_binding_desc[2].inputRate                       = VK_VERTEX_INPUT_RATE_VERTEX;
 
-   VkVertexInputAttributeDescription vertex_attribute_desc[3] = {};
-   vertex_attribute_desc[0].location                          = 0;
-   vertex_attribute_desc[0].binding                           = 0;
-   vertex_attribute_desc[0].format                            = VK_FORMAT_R32G32B32_SFLOAT;
-   vertex_attribute_desc[0].offset                            = 0;
-   vertex_attribute_desc[1].location                          = 1;
-   vertex_attribute_desc[1].binding                           = 1;
-   vertex_attribute_desc[1].format                            = VK_FORMAT_R32G32_SFLOAT;
-   vertex_attribute_desc[1].offset                            = 0;
-   vertex_attribute_desc[2].location                          = 2;
-   vertex_attribute_desc[2].binding                           = 2;
-   vertex_attribute_desc[2].format                            = VK_FORMAT_R32G32B32_SFLOAT;
-   vertex_attribute_desc[2].offset                            = 0;
+    VkVertexInputAttributeDescription vertex_attribute_desc[3] = {};
+    vertex_attribute_desc[0].location                          = 0;
+    vertex_attribute_desc[0].binding                           = 0;
+    vertex_attribute_desc[0].format                            = VK_FORMAT_R32G32B32_SFLOAT;
+    vertex_attribute_desc[0].offset                            = 0;
+    vertex_attribute_desc[1].location                          = 1;
+    vertex_attribute_desc[1].binding                           = 1;
+    vertex_attribute_desc[1].format                            = VK_FORMAT_R32G32_SFLOAT;
+    vertex_attribute_desc[1].offset                            = 0;
+    vertex_attribute_desc[2].location                          = 2;
+    vertex_attribute_desc[2].binding                           = 2;
+    vertex_attribute_desc[2].format                            = VK_FORMAT_R32G32B32_SFLOAT;
+    vertex_attribute_desc[2].offset                            = 0;
 
-   VkPipelineVertexInputStateCreateInfo vertex_input_state = {VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
-   vertex_input_state.vertexBindingDescriptionCount        = 3;
-   vertex_input_state.pVertexBindingDescriptions           = vertex_binding_desc;
-   vertex_input_state.vertexAttributeDescriptionCount      = 3;
-   vertex_input_state.pVertexAttributeDescriptions         = vertex_attribute_desc;
+    VkPipelineVertexInputStateCreateInfo vertex_input_state = {VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
+    vertex_input_state.vertexBindingDescriptionCount        = 3;
+    vertex_input_state.pVertexBindingDescriptions           = vertex_binding_desc;
+    vertex_input_state.vertexAttributeDescriptionCount      = 3;
+    vertex_input_state.pVertexAttributeDescriptions         = vertex_attribute_desc;
 
-   VkPipelineInputAssemblyStateCreateInfo input_assembly = {VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
-   input_assembly.topology                               = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    VkPipelineInputAssemblyStateCreateInfo input_assembly = {VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
+    input_assembly.topology                               = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 
-   VkPipelineViewportStateCreateInfo viewport_state = {VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO};
-   viewport_state.viewportCount                     = 1;
-   viewport_state.scissorCount                      = 1;
+    VkPipelineViewportStateCreateInfo viewport_state = {VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO};
+    viewport_state.viewportCount                     = 1;
+    viewport_state.scissorCount                      = 1;
 
-   VkPipelineRasterizationStateCreateInfo rasterization_state = {VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
-   rasterization_state.depthClampEnable                       = VK_FALSE;
-   rasterization_state.rasterizerDiscardEnable                = VK_FALSE;
-   rasterization_state.polygonMode                            = VK_POLYGON_MODE_FILL;
-   rasterization_state.cullMode                               = cullMode;
-   rasterization_state.frontFace                              = VK_FRONT_FACE_COUNTER_CLOCKWISE;
-   rasterization_state.depthBiasEnable                        = VK_TRUE;
-   rasterization_state.depthBiasConstantFactor                = 0.0f;
-   rasterization_state.depthBiasClamp                         = 0.0f;
-   rasterization_state.depthBiasSlopeFactor                   = 1.0f;
-   rasterization_state.lineWidth                              = 1.0f;
+    VkPipelineRasterizationStateCreateInfo rasterization_state = {VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
+    rasterization_state.depthClampEnable                       = VK_FALSE;
+    rasterization_state.rasterizerDiscardEnable                = VK_FALSE;
+    rasterization_state.polygonMode                            = VK_POLYGON_MODE_FILL;
+    rasterization_state.cullMode                               = cullMode;
+    rasterization_state.frontFace                              = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rasterization_state.depthBiasEnable                        = VK_TRUE;
+    rasterization_state.depthBiasConstantFactor                = 0.0f;
+    rasterization_state.depthBiasClamp                         = 0.0f;
+    rasterization_state.depthBiasSlopeFactor                   = 1.0f;
+    rasterization_state.lineWidth                              = 1.0f;
 
-   VkPipelineDepthStencilStateCreateInfo depth_stencil_state = {VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
-   depth_stencil_state.depthTestEnable                       = (dsvFormat != VK_FORMAT_UNDEFINED);
-   depth_stencil_state.depthWriteEnable                      = (dsvFormat != VK_FORMAT_UNDEFINED);
-   depth_stencil_state.depthCompareOp                        = VK_COMPARE_OP_LESS_OR_EQUAL;
-   depth_stencil_state.depthBoundsTestEnable                 = VK_FALSE;
-   depth_stencil_state.stencilTestEnable                     = VK_FALSE;
-   depth_stencil_state.front.failOp                          = VK_STENCIL_OP_KEEP;
-   depth_stencil_state.front.depthFailOp                     = VK_STENCIL_OP_KEEP;
-   depth_stencil_state.front.compareOp                       = VK_COMPARE_OP_ALWAYS;
-   depth_stencil_state.back                                  = depth_stencil_state.front;
+    VkPipelineDepthStencilStateCreateInfo depth_stencil_state = {VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
+    depth_stencil_state.depthTestEnable                       = (dsvFormat != VK_FORMAT_UNDEFINED);
+    depth_stencil_state.depthWriteEnable                      = (dsvFormat != VK_FORMAT_UNDEFINED);
+    depth_stencil_state.depthCompareOp                        = VK_COMPARE_OP_LESS_OR_EQUAL;
+    depth_stencil_state.depthBoundsTestEnable                 = VK_FALSE;
+    depth_stencil_state.stencilTestEnable                     = VK_FALSE;
+    depth_stencil_state.front.failOp                          = VK_STENCIL_OP_KEEP;
+    depth_stencil_state.front.depthFailOp                     = VK_STENCIL_OP_KEEP;
+    depth_stencil_state.front.compareOp                       = VK_COMPARE_OP_ALWAYS;
+    depth_stencil_state.back                                  = depth_stencil_state.front;
 
-   VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
-   color_blend_attachment_state.blendEnable                         = VK_FALSE;
-   color_blend_attachment_state.srcColorBlendFactor                 = VK_BLEND_FACTOR_SRC_COLOR;
-   color_blend_attachment_state.dstColorBlendFactor                 = VK_BLEND_FACTOR_ZERO;
-   color_blend_attachment_state.colorBlendOp                        = VK_BLEND_OP_ADD;
-   color_blend_attachment_state.srcAlphaBlendFactor                 = VK_BLEND_FACTOR_SRC_ALPHA;
-   color_blend_attachment_state.dstAlphaBlendFactor                 = VK_BLEND_FACTOR_ZERO;
-   color_blend_attachment_state.alphaBlendOp                        = VK_BLEND_OP_ADD;
-   color_blend_attachment_state.colorWriteMask                      = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_A_BIT;
+    VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
+    color_blend_attachment_state.blendEnable                         = VK_FALSE;
+    color_blend_attachment_state.srcColorBlendFactor                 = VK_BLEND_FACTOR_SRC_COLOR;
+    color_blend_attachment_state.dstColorBlendFactor                 = VK_BLEND_FACTOR_ZERO;
+    color_blend_attachment_state.colorBlendOp                        = VK_BLEND_OP_ADD;
+    color_blend_attachment_state.srcAlphaBlendFactor                 = VK_BLEND_FACTOR_SRC_ALPHA;
+    color_blend_attachment_state.dstAlphaBlendFactor                 = VK_BLEND_FACTOR_ZERO;
+    color_blend_attachment_state.alphaBlendOp                        = VK_BLEND_OP_ADD;
+    color_blend_attachment_state.colorWriteMask                      = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_A_BIT;
 
-   VkPipelineColorBlendStateCreateInfo color_blend_state = {VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO};
-   color_blend_state.logicOpEnable                       = VK_FALSE;
-   color_blend_state.logicOp                             = VK_LOGIC_OP_NO_OP;
-   color_blend_state.attachmentCount                     = 1;
-   color_blend_state.pAttachments                        = &color_blend_attachment_state;
-   color_blend_state.blendConstants[0]                   = 0.0f;
-   color_blend_state.blendConstants[1]                   = 0.0f;
-   color_blend_state.blendConstants[2]                   = 0.0f;
-   color_blend_state.blendConstants[3]                   = 0.0f;
+    VkPipelineColorBlendStateCreateInfo color_blend_state = {VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO};
+    color_blend_state.logicOpEnable                       = VK_FALSE;
+    color_blend_state.logicOp                             = VK_LOGIC_OP_NO_OP;
+    color_blend_state.attachmentCount                     = 1;
+    color_blend_state.pAttachments                        = &color_blend_attachment_state;
+    color_blend_state.blendConstants[0]                   = 0.0f;
+    color_blend_state.blendConstants[1]                   = 0.0f;
+    color_blend_state.blendConstants[2]                   = 0.0f;
+    color_blend_state.blendConstants[3]                   = 0.0f;
 
-   VkDynamicState dynamic_states[2] = {};
-   dynamic_states[0]                = VK_DYNAMIC_STATE_VIEWPORT;
-   dynamic_states[1]                = VK_DYNAMIC_STATE_SCISSOR;
+    VkDynamicState dynamic_states[2] = {};
+    dynamic_states[0]                = VK_DYNAMIC_STATE_VIEWPORT;
+    dynamic_states[1]                = VK_DYNAMIC_STATE_SCISSOR;
 
-   VkPipelineDynamicStateCreateInfo dynamic_state = {VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
-   dynamic_state.dynamicStateCount                = 2;
-   dynamic_state.pDynamicStates                   = dynamic_states;
+    VkPipelineDynamicStateCreateInfo dynamic_state = {VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
+    dynamic_state.dynamicStateCount                = 2;
+    dynamic_state.pDynamicStates                   = dynamic_states;
 
-   VkGraphicsPipelineCreateInfo pipeline_info = {VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
-   pipeline_info.flags                        = VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-   pipeline_info.pNext                        = &pipeline_rendering_create_info;
-   pipeline_info.stageCount                   = 2;
-   pipeline_info.pStages                      = shader_stages;
-   pipeline_info.pVertexInputState            = &vertex_input_state;
-   pipeline_info.pInputAssemblyState          = &input_assembly;
-   pipeline_info.pViewportState               = &viewport_state;
-   pipeline_info.pRasterizationState          = &rasterization_state;
-   pipeline_info.pDepthStencilState           = &depth_stencil_state;
-   pipeline_info.pColorBlendState             = &color_blend_state;
-   pipeline_info.pDynamicState                = &dynamic_state;
-   pipeline_info.layout                       = pipelineLayout;
-   pipeline_info.renderPass                   = VK_NULL_HANDLE;
-   pipeline_info.subpass                      = 0;
-   pipeline_info.basePipelineHandle           = VK_NULL_HANDLE;
-   pipeline_info.basePipelineIndex            = -1;
+    VkPipelineMultisampleStateCreateInfo pipelineMultiStateCreateInfo = {VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
+    pipelineMultiStateCreateInfo.rasterizationSamples                 = VK_SAMPLE_COUNT_1_BIT;
 
-   VkResult vkres = vkCreateGraphicsPipelines(
-       pRenderer->Device,
-       VK_NULL_HANDLE, // Not using a pipeline cache
-       1,
-       &pipeline_info,
-       nullptr,
-       pPipeline);
+    VkGraphicsPipelineCreateInfo pipeline_info = {VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
+    pipeline_info.flags                        = VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    pipeline_info.pNext                        = &pipeline_rendering_create_info;
+    pipeline_info.stageCount                   = 2;
+    pipeline_info.pStages                      = shader_stages;
+    pipeline_info.pVertexInputState            = &vertex_input_state;
+    pipeline_info.pInputAssemblyState          = &input_assembly;
+    pipeline_info.pViewportState               = &viewport_state;
+    pipeline_info.pRasterizationState          = &rasterization_state;
+    pipeline_info.pMultisampleState            = &pipelineMultiStateCreateInfo;
+    pipeline_info.pDepthStencilState           = &depth_stencil_state;
+    pipeline_info.pColorBlendState             = &color_blend_state;
+    pipeline_info.pDynamicState                = &dynamic_state;
+    pipeline_info.layout                       = pipelineLayout;
+    pipeline_info.renderPass                   = VK_NULL_HANDLE;
+    pipeline_info.subpass                      = 0;
+    pipeline_info.basePipelineHandle           = VK_NULL_HANDLE;
+    pipeline_info.basePipelineIndex            = -1;
 
-   return vkres;
+    VkResult vkres = vkCreateGraphicsPipelines(
+        pRenderer->Device,
+        VK_NULL_HANDLE, // Not using a pipeline cache
+        1,
+        &pipeline_info,
+        nullptr,
+        pPipeline);
+
+    return vkres;
 }
 
 HRESULT CreateGraphicsPipeline1(
@@ -2182,162 +2195,166 @@ HRESULT CreateGraphicsPipeline1(
    VkPipeline*          pPipeline,
    VkCullModeFlagBits   cullMode)
 {
-   VkPipelineRenderingCreateInfo pipeline_rendering_create_info = { VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO };
-   pipeline_rendering_create_info.colorAttachmentCount          = 1;
-   pipeline_rendering_create_info.pColorAttachmentFormats       = &rtvFormat;
-   pipeline_rendering_create_info.depthAttachmentFormat         = dsvFormat;
+    VkPipelineRenderingCreateInfo pipeline_rendering_create_info = {VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO};
+    pipeline_rendering_create_info.colorAttachmentCount          = 1;
+    pipeline_rendering_create_info.pColorAttachmentFormats       = &rtvFormat;
+    pipeline_rendering_create_info.depthAttachmentFormat         = dsvFormat;
 
-   VkPipelineShaderStageCreateInfo shader_stages[2]             = { VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO };
-   shader_stages[0].stage                                       = VK_SHADER_STAGE_VERTEX_BIT;
-   shader_stages[0].module                                      = vsShaderModule;
-   shader_stages[0].pName                                       = "vsmain";
-   shader_stages[1].sType                                       = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-   shader_stages[1].stage                                       = VK_SHADER_STAGE_FRAGMENT_BIT;
-   shader_stages[1].module                                      = fsShaderModule;
-   shader_stages[1].pName                                       = "psmain";
+    VkPipelineShaderStageCreateInfo shader_stages[2] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
+    shader_stages[0].stage                           = VK_SHADER_STAGE_VERTEX_BIT;
+    shader_stages[0].module                          = vsShaderModule;
+    shader_stages[0].pName                           = "vsmain";
+    shader_stages[1].sType                           = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    shader_stages[1].stage                           = VK_SHADER_STAGE_FRAGMENT_BIT;
+    shader_stages[1].module                          = fsShaderModule;
+    shader_stages[1].pName                           = "psmain";
 
-   const uint32_t kNumInputElements = 5;
+    const uint32_t kNumInputElements = 5;
 
-   VkVertexInputBindingDescription vertex_binding_desc[kNumInputElements] = {};
-   // Position
-   vertex_binding_desc[0].binding                               = 0;
-   vertex_binding_desc[0].stride                                = 12;
-   vertex_binding_desc[0].inputRate                             = VK_VERTEX_INPUT_RATE_VERTEX;
-   // TexCoord
-   vertex_binding_desc[1].binding                               = 1;
-   vertex_binding_desc[1].stride                                = 8;
-   vertex_binding_desc[1].inputRate                             = VK_VERTEX_INPUT_RATE_VERTEX;
-   // Normal
-   vertex_binding_desc[2].binding                               = 2;
-   vertex_binding_desc[2].stride                                = 12;
-   vertex_binding_desc[2].inputRate                             = VK_VERTEX_INPUT_RATE_VERTEX;
-   // Tangent
-   vertex_binding_desc[3].binding                               = 3;
-   vertex_binding_desc[3].stride                                = 12;
-   vertex_binding_desc[3].inputRate                             = VK_VERTEX_INPUT_RATE_VERTEX;
-   // Bitangent
-   vertex_binding_desc[4].binding                               = 4;
-   vertex_binding_desc[4].stride                                = 12;
-   vertex_binding_desc[4].inputRate                             = VK_VERTEX_INPUT_RATE_VERTEX;
+    VkVertexInputBindingDescription vertex_binding_desc[kNumInputElements] = {};
+    // Position
+    vertex_binding_desc[0].binding   = 0;
+    vertex_binding_desc[0].stride    = 12;
+    vertex_binding_desc[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+    // TexCoord
+    vertex_binding_desc[1].binding   = 1;
+    vertex_binding_desc[1].stride    = 8;
+    vertex_binding_desc[1].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+    // Normal
+    vertex_binding_desc[2].binding   = 2;
+    vertex_binding_desc[2].stride    = 12;
+    vertex_binding_desc[2].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+    // Tangent
+    vertex_binding_desc[3].binding   = 3;
+    vertex_binding_desc[3].stride    = 12;
+    vertex_binding_desc[3].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+    // Bitangent
+    vertex_binding_desc[4].binding   = 4;
+    vertex_binding_desc[4].stride    = 12;
+    vertex_binding_desc[4].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
 
-   VkVertexInputAttributeDescription vertex_attribute_desc[kNumInputElements] = {};
-   // Position
-   vertex_attribute_desc[0].location                            = 0;
-   vertex_attribute_desc[0].binding                             = 0;
-   vertex_attribute_desc[0].format                              = VK_FORMAT_R32G32B32_SFLOAT;
-   vertex_attribute_desc[0].offset                              = 0;
-   // TexCoord
-   vertex_attribute_desc[1].location                            = 1;
-   vertex_attribute_desc[1].binding                             = 1;
-   vertex_attribute_desc[1].format                              = VK_FORMAT_R32G32_SFLOAT;
-   vertex_attribute_desc[1].offset                              = 0;
-   // Normal
-   vertex_attribute_desc[2].location                            = 2;
-   vertex_attribute_desc[2].binding                             = 2;
-   vertex_attribute_desc[2].format                              = VK_FORMAT_R32G32B32_SFLOAT;
-   vertex_attribute_desc[2].offset                              = 0;
-   // Tangent
-   vertex_attribute_desc[3].location                            = 3;
-   vertex_attribute_desc[3].binding                             = 3;
-   vertex_attribute_desc[3].format                              = VK_FORMAT_R32G32B32_SFLOAT;
-   vertex_attribute_desc[3].offset                              = 0;
-   // Bitangent
-   vertex_attribute_desc[4].location                            = 4;
-   vertex_attribute_desc[4].binding                             = 4;
-   vertex_attribute_desc[4].format                              = VK_FORMAT_R32G32B32_SFLOAT;
-   vertex_attribute_desc[4].offset                              = 0;
+    VkVertexInputAttributeDescription vertex_attribute_desc[kNumInputElements] = {};
+    // Position
+    vertex_attribute_desc[0].location = 0;
+    vertex_attribute_desc[0].binding  = 0;
+    vertex_attribute_desc[0].format   = VK_FORMAT_R32G32B32_SFLOAT;
+    vertex_attribute_desc[0].offset   = 0;
+    // TexCoord
+    vertex_attribute_desc[1].location = 1;
+    vertex_attribute_desc[1].binding  = 1;
+    vertex_attribute_desc[1].format   = VK_FORMAT_R32G32_SFLOAT;
+    vertex_attribute_desc[1].offset   = 0;
+    // Normal
+    vertex_attribute_desc[2].location = 2;
+    vertex_attribute_desc[2].binding  = 2;
+    vertex_attribute_desc[2].format   = VK_FORMAT_R32G32B32_SFLOAT;
+    vertex_attribute_desc[2].offset   = 0;
+    // Tangent
+    vertex_attribute_desc[3].location = 3;
+    vertex_attribute_desc[3].binding  = 3;
+    vertex_attribute_desc[3].format   = VK_FORMAT_R32G32B32_SFLOAT;
+    vertex_attribute_desc[3].offset   = 0;
+    // Bitangent
+    vertex_attribute_desc[4].location = 4;
+    vertex_attribute_desc[4].binding  = 4;
+    vertex_attribute_desc[4].format   = VK_FORMAT_R32G32B32_SFLOAT;
+    vertex_attribute_desc[4].offset   = 0;
 
-   VkPipelineVertexInputStateCreateInfo vertex_input_state      = { VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO };
-   vertex_input_state.vertexBindingDescriptionCount             = kNumInputElements;
-   vertex_input_state.pVertexBindingDescriptions                = vertex_binding_desc;
-   vertex_input_state.vertexAttributeDescriptionCount           = kNumInputElements;
-   vertex_input_state.pVertexAttributeDescriptions              = vertex_attribute_desc;
+    VkPipelineVertexInputStateCreateInfo vertex_input_state = {VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
+    vertex_input_state.vertexBindingDescriptionCount        = kNumInputElements;
+    vertex_input_state.pVertexBindingDescriptions           = vertex_binding_desc;
+    vertex_input_state.vertexAttributeDescriptionCount      = kNumInputElements;
+    vertex_input_state.pVertexAttributeDescriptions         = vertex_attribute_desc;
 
-   VkPipelineInputAssemblyStateCreateInfo input_assembly        = { VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO };
-   input_assembly.topology                                      = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    VkPipelineInputAssemblyStateCreateInfo input_assembly = {VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
+    input_assembly.topology                               = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 
-   VkPipelineViewportStateCreateInfo viewport_state             = { VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };
-   viewport_state.viewportCount                                 = 1;
-   viewport_state.scissorCount                                  = 1;
+    VkPipelineViewportStateCreateInfo viewport_state = {VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO};
+    viewport_state.viewportCount                     = 1;
+    viewport_state.scissorCount                      = 1;
 
-   VkPipelineRasterizationStateCreateInfo rasterization_state   = { VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO };
-   rasterization_state.depthClampEnable                         = VK_FALSE;
-   rasterization_state.rasterizerDiscardEnable                  = VK_FALSE;
-   rasterization_state.polygonMode                              = VK_POLYGON_MODE_FILL;
-   rasterization_state.cullMode                                 = cullMode;
-   rasterization_state.frontFace                                = VK_FRONT_FACE_COUNTER_CLOCKWISE;
-   rasterization_state.depthBiasEnable                          = VK_TRUE;
-   rasterization_state.depthBiasConstantFactor                  = 0.0f;
-   rasterization_state.depthBiasClamp                           = 0.0f;
-   rasterization_state.depthBiasSlopeFactor                     = 1.0f;
-   rasterization_state.lineWidth                                = 1.0f;
+    VkPipelineRasterizationStateCreateInfo rasterization_state = {VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
+    rasterization_state.depthClampEnable                       = VK_FALSE;
+    rasterization_state.rasterizerDiscardEnable                = VK_FALSE;
+    rasterization_state.polygonMode                            = VK_POLYGON_MODE_FILL;
+    rasterization_state.cullMode                               = cullMode;
+    rasterization_state.frontFace                              = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rasterization_state.depthBiasEnable                        = VK_TRUE;
+    rasterization_state.depthBiasConstantFactor                = 0.0f;
+    rasterization_state.depthBiasClamp                         = 0.0f;
+    rasterization_state.depthBiasSlopeFactor                   = 1.0f;
+    rasterization_state.lineWidth                              = 1.0f;
 
-   VkPipelineDepthStencilStateCreateInfo depth_stencil_state    = { VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO };
-   depth_stencil_state.depthTestEnable                          = (dsvFormat != VK_FORMAT_UNDEFINED);
-   depth_stencil_state.depthWriteEnable                         = (dsvFormat != VK_FORMAT_UNDEFINED);
-   depth_stencil_state.depthCompareOp                           = VK_COMPARE_OP_LESS_OR_EQUAL;
-   depth_stencil_state.depthBoundsTestEnable                    = VK_FALSE;
-   depth_stencil_state.stencilTestEnable                        = VK_FALSE;
-   depth_stencil_state.front.failOp                             = VK_STENCIL_OP_KEEP;
-   depth_stencil_state.front.depthFailOp                        = VK_STENCIL_OP_KEEP;
-   depth_stencil_state.front.compareOp                          = VK_COMPARE_OP_ALWAYS;
-   depth_stencil_state.back                                     = depth_stencil_state.front;
+    VkPipelineDepthStencilStateCreateInfo depth_stencil_state = {VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
+    depth_stencil_state.depthTestEnable                       = (dsvFormat != VK_FORMAT_UNDEFINED);
+    depth_stencil_state.depthWriteEnable                      = (dsvFormat != VK_FORMAT_UNDEFINED);
+    depth_stencil_state.depthCompareOp                        = VK_COMPARE_OP_LESS_OR_EQUAL;
+    depth_stencil_state.depthBoundsTestEnable                 = VK_FALSE;
+    depth_stencil_state.stencilTestEnable                     = VK_FALSE;
+    depth_stencil_state.front.failOp                          = VK_STENCIL_OP_KEEP;
+    depth_stencil_state.front.depthFailOp                     = VK_STENCIL_OP_KEEP;
+    depth_stencil_state.front.compareOp                       = VK_COMPARE_OP_ALWAYS;
+    depth_stencil_state.back                                  = depth_stencil_state.front;
 
-   VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
-   color_blend_attachment_state.blendEnable                     = VK_FALSE;
-   color_blend_attachment_state.srcColorBlendFactor             = VK_BLEND_FACTOR_SRC_COLOR;
-   color_blend_attachment_state.dstColorBlendFactor             = VK_BLEND_FACTOR_ZERO;
-   color_blend_attachment_state.colorBlendOp                    = VK_BLEND_OP_ADD;
-   color_blend_attachment_state.srcAlphaBlendFactor             = VK_BLEND_FACTOR_SRC_ALPHA;
-   color_blend_attachment_state.dstAlphaBlendFactor             = VK_BLEND_FACTOR_ZERO;
-   color_blend_attachment_state.alphaBlendOp                    = VK_BLEND_OP_ADD;
-   color_blend_attachment_state.colorWriteMask                  = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_A_BIT;
+    VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
+    color_blend_attachment_state.blendEnable                         = VK_FALSE;
+    color_blend_attachment_state.srcColorBlendFactor                 = VK_BLEND_FACTOR_SRC_COLOR;
+    color_blend_attachment_state.dstColorBlendFactor                 = VK_BLEND_FACTOR_ZERO;
+    color_blend_attachment_state.colorBlendOp                        = VK_BLEND_OP_ADD;
+    color_blend_attachment_state.srcAlphaBlendFactor                 = VK_BLEND_FACTOR_SRC_ALPHA;
+    color_blend_attachment_state.dstAlphaBlendFactor                 = VK_BLEND_FACTOR_ZERO;
+    color_blend_attachment_state.alphaBlendOp                        = VK_BLEND_OP_ADD;
+    color_blend_attachment_state.colorWriteMask                      = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_A_BIT;
 
-   VkPipelineColorBlendStateCreateInfo color_blend_state = { VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO };
-   color_blend_state.logicOpEnable                              = VK_FALSE;
-   color_blend_state.logicOp                                    = VK_LOGIC_OP_NO_OP;
-   color_blend_state.attachmentCount                            = 1;
-   color_blend_state.pAttachments                               = &color_blend_attachment_state;
-   color_blend_state.blendConstants[0]                          = 0.0f;
-   color_blend_state.blendConstants[1]                          = 0.0f;
-   color_blend_state.blendConstants[2]                          = 0.0f;
-   color_blend_state.blendConstants[3]                          = 0.0f;
+    VkPipelineColorBlendStateCreateInfo color_blend_state = {VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO};
+    color_blend_state.logicOpEnable                       = VK_FALSE;
+    color_blend_state.logicOp                             = VK_LOGIC_OP_NO_OP;
+    color_blend_state.attachmentCount                     = 1;
+    color_blend_state.pAttachments                        = &color_blend_attachment_state;
+    color_blend_state.blendConstants[0]                   = 0.0f;
+    color_blend_state.blendConstants[1]                   = 0.0f;
+    color_blend_state.blendConstants[2]                   = 0.0f;
+    color_blend_state.blendConstants[3]                   = 0.0f;
 
-   VkDynamicState dynamic_states[2]                             = {};
-   dynamic_states[0]                                            = VK_DYNAMIC_STATE_VIEWPORT;
-   dynamic_states[1]                                            = VK_DYNAMIC_STATE_SCISSOR;
+    VkDynamicState dynamic_states[2] = {};
+    dynamic_states[0]                = VK_DYNAMIC_STATE_VIEWPORT;
+    dynamic_states[1]                = VK_DYNAMIC_STATE_SCISSOR;
 
-   VkPipelineDynamicStateCreateInfo dynamic_state               = { VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO };
-   dynamic_state.dynamicStateCount                              = 2;
-   dynamic_state.pDynamicStates                                 = dynamic_states;
+    VkPipelineDynamicStateCreateInfo dynamic_state = {VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
+    dynamic_state.dynamicStateCount                = 2;
+    dynamic_state.pDynamicStates                   = dynamic_states;
 
-   VkGraphicsPipelineCreateInfo pipeline_info                   = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO };
-   pipeline_info.flags                                          = VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-   pipeline_info.pNext                                          = &pipeline_rendering_create_info;
-   pipeline_info.stageCount                                     = 2;
-   pipeline_info.pStages                                        = shader_stages;
-   pipeline_info.pVertexInputState                              = &vertex_input_state;
-   pipeline_info.pInputAssemblyState                            = &input_assembly;
-   pipeline_info.pViewportState                                 = &viewport_state;
-   pipeline_info.pRasterizationState                            = &rasterization_state;
-   pipeline_info.pDepthStencilState                             = &depth_stencil_state;
-   pipeline_info.pColorBlendState                               = &color_blend_state;
-   pipeline_info.pDynamicState                                  = &dynamic_state;
-   pipeline_info.layout                                         = pipelineLayout;
-   pipeline_info.renderPass                                     = VK_NULL_HANDLE;
-   pipeline_info.subpass                                        = 0;
-   pipeline_info.basePipelineHandle                             = VK_NULL_HANDLE;
-   pipeline_info.basePipelineIndex                              = -1;
+    VkPipelineMultisampleStateCreateInfo pipelineMultiStateCreateInfo = {VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
+    pipelineMultiStateCreateInfo.rasterizationSamples                 = VK_SAMPLE_COUNT_1_BIT;
 
-   VkResult vkres = vkCreateGraphicsPipelines(
-      pRenderer->Device,
-      VK_NULL_HANDLE, // Not using a pipeline cache
-      1,
-      &pipeline_info,
-      nullptr,
-      pPipeline);
+    VkGraphicsPipelineCreateInfo pipeline_info = {VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
+    pipeline_info.flags                        = VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    pipeline_info.pNext                        = &pipeline_rendering_create_info;
+    pipeline_info.stageCount                   = 2;
+    pipeline_info.pStages                      = shader_stages;
+    pipeline_info.pVertexInputState            = &vertex_input_state;
+    pipeline_info.pInputAssemblyState          = &input_assembly;
+    pipeline_info.pViewportState               = &viewport_state;
+    pipeline_info.pRasterizationState          = &rasterization_state;
+    pipeline_info.pMultisampleState            = &pipelineMultiStateCreateInfo;
+    pipeline_info.pDepthStencilState           = &depth_stencil_state;
+    pipeline_info.pColorBlendState             = &color_blend_state;
+    pipeline_info.pDynamicState                = &dynamic_state;
+    pipeline_info.layout                       = pipelineLayout;
+    pipeline_info.renderPass                   = VK_NULL_HANDLE;
+    pipeline_info.subpass                      = 0;
+    pipeline_info.basePipelineHandle           = VK_NULL_HANDLE;
+    pipeline_info.basePipelineIndex            = -1;
 
-   return vkres;
+    VkResult vkres = vkCreateGraphicsPipelines(
+        pRenderer->Device,
+        VK_NULL_HANDLE, // Not using a pipeline cache
+        1,
+        &pipeline_info,
+        nullptr,
+        pPipeline);
+
+    return vkres;
 }
 
 CompileResult CompileGLSL(

--- a/projects/pbr/202_pbr_spheres_vulkan/202_pbr_spheres_vulkan.cpp
+++ b/projects/pbr/202_pbr_spheres_vulkan/202_pbr_spheres_vulkan.cpp
@@ -287,7 +287,9 @@ int main(int argc, char** argv)
        GREX_DEFAULT_RTV_FORMAT,
        GREX_DEFAULT_DSV_FORMAT,
        &envPipelineState,
-       VK_CULL_MODE_FRONT_BIT));
+       VK_CULL_MODE_FRONT_BIT,
+        "vsmain",
+        "psmain"));
 
     // *************************************************************************
     // Scene Params Buffer

--- a/projects/pbr/204_pbr_camera_vulkan/204_pbr_camera_vulkan.cpp
+++ b/projects/pbr/204_pbr_camera_vulkan/204_pbr_camera_vulkan.cpp
@@ -307,7 +307,9 @@ int main(int argc, char** argv)
       GREX_DEFAULT_RTV_FORMAT,
       GREX_DEFAULT_DSV_FORMAT,
       &envPipelineState,
-      VK_CULL_MODE_FRONT_BIT));
+      VK_CULL_MODE_FRONT_BIT,
+       "vsmain",
+       "psmain"));
 
    // *************************************************************************
    // Constant buffer

--- a/projects/pbr/206_pbr_align_vulkan/206_pbr_align_vulkan.cpp
+++ b/projects/pbr/206_pbr_align_vulkan/206_pbr_align_vulkan.cpp
@@ -287,7 +287,9 @@ int main(int argc, char** argv)
        GREX_DEFAULT_RTV_FORMAT,
        GREX_DEFAULT_DSV_FORMAT,
        &envPipelineState,
-       VK_CULL_MODE_FRONT_BIT));
+       VK_CULL_MODE_FRONT_BIT,
+        "vsmain",
+        "psmain"));
 
     // *************************************************************************
     // Scene Params Buffer

--- a/projects/pbr/252_pbr_explorer_vulkan/252_pbr_explorer_vulkan.cpp
+++ b/projects/pbr/252_pbr_explorer_vulkan/252_pbr_explorer_vulkan.cpp
@@ -431,7 +431,9 @@ int main(int argc, char** argv)
         GREX_DEFAULT_RTV_FORMAT,
         GREX_DEFAULT_DSV_FORMAT,
         &envPipelineState,
-        VK_CULL_MODE_FRONT_BIT));
+        VK_CULL_MODE_FRONT_BIT,
+        "vsmain",
+        "psmain"));
 
     // *************************************************************************
     // Material buffer

--- a/projects/pbr/256_pbr_material_textures_vulkan/256_pbr_material_textures_vulkan.cpp
+++ b/projects/pbr/256_pbr_material_textures_vulkan/256_pbr_material_textures_vulkan.cpp
@@ -333,7 +333,9 @@ int main(int argc, char** argv)
         GREX_DEFAULT_RTV_FORMAT,
         GREX_DEFAULT_DSV_FORMAT,
         &envPipelineState,
-        VK_CULL_MODE_FRONT_BIT));
+        VK_CULL_MODE_FRONT_BIT,
+        "vsmain",
+        "psmain"));
 
     // *************************************************************************
     // Constant buffer

--- a/projects/raytracing/002_raytracing_basic_vulkan/002_raytracing_basic_vulkan.cpp
+++ b/projects/raytracing/002_raytracing_basic_vulkan/002_raytracing_basic_vulkan.cpp
@@ -390,7 +390,7 @@ int main(int argc, char** argv)
             VkImageViewCreateInfo createInfo           = {VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
             createInfo.image                           = image;
             createInfo.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-            createInfo.format                          = VK_FORMAT_R8G8B8A8_UNORM;
+            createInfo.format                          = GREX_DEFAULT_RTV_FORMAT;
             createInfo.components                      = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
             createInfo.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
             createInfo.subresourceRange.baseMipLevel   = 0;

--- a/projects/raytracing/004_basic_procedural_vulkan/004_basic_procedural_vulkan.cpp
+++ b/projects/raytracing/004_basic_procedural_vulkan/004_basic_procedural_vulkan.cpp
@@ -462,7 +462,7 @@ int main(int argc, char** argv)
             VkImageViewCreateInfo createInfo           = {VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
             createInfo.image                           = image;
             createInfo.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-            createInfo.format                          = VK_FORMAT_R8G8B8A8_UNORM;
+            createInfo.format                          = GREX_DEFAULT_RTV_FORMAT;
             createInfo.components                      = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
             createInfo.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
             createInfo.subresourceRange.baseMipLevel   = 0;

--- a/projects/raytracing/006_sphereflake_vulkan/006_sphereflake_vulkan.cpp
+++ b/projects/raytracing/006_sphereflake_vulkan/006_sphereflake_vulkan.cpp
@@ -512,7 +512,7 @@ int main(int argc, char** argv)
             VkImageViewCreateInfo createInfo           = {VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
             createInfo.image                           = image;
             createInfo.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-            createInfo.format                          = VK_FORMAT_R8G8B8A8_UNORM;
+            createInfo.format                          = GREX_DEFAULT_RTV_FORMAT;
             createInfo.components                      = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
             createInfo.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
             createInfo.subresourceRange.baseMipLevel   = 0;

--- a/projects/raytracing/008_basic_reflection_vulkan/008_basic_reflection_vulkan.cpp
+++ b/projects/raytracing/008_basic_reflection_vulkan/008_basic_reflection_vulkan.cpp
@@ -599,7 +599,7 @@ int main(int argc, char** argv)
             VkImageViewCreateInfo createInfo           = {VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
             createInfo.image                           = image;
             createInfo.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-            createInfo.format                          = VK_FORMAT_R8G8B8A8_UNORM;
+            createInfo.format                          = GREX_DEFAULT_RTV_FORMAT;
             createInfo.components                      = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
             createInfo.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
             createInfo.subresourceRange.baseMipLevel   = 0;

--- a/projects/raytracing/010_basic_shadow_vulkan/010_basic_shadow_vulkan.cpp
+++ b/projects/raytracing/010_basic_shadow_vulkan/010_basic_shadow_vulkan.cpp
@@ -687,7 +687,7 @@ int main(int argc, char** argv)
             VkImageViewCreateInfo createInfo           = {VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
             createInfo.image                           = image;
             createInfo.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-            createInfo.format                          = VK_FORMAT_R8G8B8A8_UNORM;
+            createInfo.format                          = GREX_DEFAULT_RTV_FORMAT;
             createInfo.components                      = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
             createInfo.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
             createInfo.subresourceRange.baseMipLevel   = 0;

--- a/projects/raytracing/012_basic_shadow_dynamic_vulkan/012_basic_shadow_dynamic_vulkan.cpp
+++ b/projects/raytracing/012_basic_shadow_dynamic_vulkan/012_basic_shadow_dynamic_vulkan.cpp
@@ -688,7 +688,7 @@ int main(int argc, char** argv)
             VkImageViewCreateInfo createInfo           = {VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
             createInfo.image                           = image;
             createInfo.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
-            createInfo.format                          = VK_FORMAT_R8G8B8A8_UNORM;
+            createInfo.format                          = GREX_DEFAULT_RTV_FORMAT;
             createInfo.components                      = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
             createInfo.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
             createInfo.subresourceRange.baseMipLevel   = 0;


### PR DESCRIPTION
Added a VkPipelineMultiplesampleStateCreateInfo to the pipeline creation of all Vulkan PSOs.

While testing I found a few other errors that I also fixed
* Some PSO creation functions changed to specify their entry point name, which older experiments weren't using
* Some of the ray tracing samples were using a SwapChain of RGBA instead of BGRA which was causing validation layer errors.