### PR TITLE
Fix Experiment 256 Texture issue

### DIFF
--- a/projects/pbr/256_pbr_material_textures_vulkan/256_pbr_material_textures_vulkan.cpp
+++ b/projects/pbr/256_pbr_material_textures_vulkan/256_pbr_material_textures_vulkan.cpp
@@ -2120,7 +2120,7 @@ void WritePBRDescriptors(
         samplerInfo.minFilter               = VK_FILTER_LINEAR;
         samplerInfo.mipmapMode              = VK_SAMPLER_MIPMAP_MODE_LINEAR;
         samplerInfo.addressModeU            = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-        samplerInfo.addressModeV            = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        samplerInfo.addressModeV            = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.addressModeW            = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
         samplerInfo.mipLodBias              = 0;
         samplerInfo.anisotropyEnable        = VK_FALSE;


### PR DESCRIPTION
Turns out the Sampler state for the Vulkan experiment had incorrect address modes. It used to be wrap/clamp/clamp when it should have bene wrap/wrap/clamp.