### PR TITLE
Fix Normals in Experiements 022 and 023

### DIFF
--- a/assets/projects/022_raytracing_multi_geo/shaders.hlsl
+++ b/assets/projects/022_raytracing_multi_geo/shaders.hlsl
@@ -14,9 +14,9 @@ struct Triangle {
 };
 
 StructuredBuffer<float3>   Materials    : register(t3);  // Material colors
-StructuredBuffer<Triangle> Triangles[2] : register(t4);  // Index buffers
-StructuredBuffer<float3>   Positions[2] : register(t7);  // Position buffers
-StructuredBuffer<float3>   Normals[2]   : register(t10); // Normal buffers
+StructuredBuffer<Triangle> Triangles[3] : register(t4);  // Index buffers
+StructuredBuffer<float3>   Positions[3] : register(t7);  // Position buffers
+StructuredBuffer<float3>   Normals[3]   : register(t10); // Normal buffers
 
 typedef BuiltInTriangleIntersectionAttributes MyAttributes;
 

--- a/assets/projects/023_raytracing_multi_instance/shaders.hlsl
+++ b/assets/projects/023_raytracing_multi_instance/shaders.hlsl
@@ -14,9 +14,9 @@ struct Triangle {
 };
 
 StructuredBuffer<float3>   Materials    : register(t3);  // Material colors
-StructuredBuffer<Triangle> Triangles[2] : register(t4);  // Index buffers
-StructuredBuffer<float3>   Positions[2] : register(t7);  // Position buffers
-StructuredBuffer<float3>   Normals[2]   : register(t10); // Normal buffers
+StructuredBuffer<Triangle> Triangles[3] : register(t4);  // Index buffers
+StructuredBuffer<float3>   Positions[3] : register(t7);  // Position buffers
+StructuredBuffer<float3>   Normals[3]   : register(t10); // Normal buffers
 
 typedef BuiltInTriangleIntersectionAttributes MyAttributes;
 

--- a/projects/raytracing/022_raytracing_multi_geo_vulkan/022_raytracing_multi_geo_vulkan.cpp
+++ b/projects/raytracing/022_raytracing_multi_geo_vulkan/022_raytracing_multi_geo_vulkan.cpp
@@ -523,21 +523,21 @@ void CreateRayTracePipelineLayout(
             VkDescriptorSetLayoutBinding binding = {};
             binding.binding                      = 4;
             binding.descriptorType               = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            binding.descriptorCount              = 2;
+            binding.descriptorCount              = 3;
             binding.stageFlags                   = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
             bindings.push_back(binding);
 
             binding                 = {};
             binding.binding         = 7;
             binding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            binding.descriptorCount = 2;
+            binding.descriptorCount = 3;
             binding.stageFlags      = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
             bindings.push_back(binding);
 
             binding                 = {};
             binding.binding         = 10;
             binding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            binding.descriptorCount = 2;
+            binding.descriptorCount = 3;
             binding.stageFlags      = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
             bindings.push_back(binding);
         }

--- a/projects/raytracing/023_raytracing_multi_instance_vulkan/023_raytracing_multi_instance_vulkan.cpp
+++ b/projects/raytracing/023_raytracing_multi_instance_vulkan/023_raytracing_multi_instance_vulkan.cpp
@@ -526,21 +526,21 @@ void CreateRayTracePipelineLayout(
             VkDescriptorSetLayoutBinding binding = {};
             binding.binding                      = 4;
             binding.descriptorType               = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            binding.descriptorCount              = 2;
+            binding.descriptorCount              = 3;
             binding.stageFlags                   = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
             bindings.push_back(binding);
 
             binding                 = {};
             binding.binding         = 7;
             binding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            binding.descriptorCount = 2;
+            binding.descriptorCount = 3;
             binding.stageFlags      = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
             bindings.push_back(binding);
 
             binding                 = {};
             binding.binding         = 10;
             binding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            binding.descriptorCount = 2;
+            binding.descriptorCount = 3;
             binding.stageFlags      = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
             bindings.push_back(binding);
         }


### PR DESCRIPTION
Turns out the .hlsl code only defined two array elements, the Vulkan code also only defined two descriptors in each array, this caused the cube to have incorrect normals, which messed up the lighting.