### PR TITLE
Update CMake Minimum Version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(GraphicsExperiments)
 

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # ------------------------------------------------------------------------------
 # Configure directories

--- a/projects/geometry/101_color_cube_d3d12/CMakeLists.txt
+++ b/projects/geometry/101_color_cube_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(101_color_cube_d3d12)
 

--- a/projects/geometry/101_color_cube_metal/CMakeLists.txt
+++ b/projects/geometry/101_color_cube_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(101_color_cube_metal)
 

--- a/projects/geometry/101_color_cube_vulkan/CMakeLists.txt
+++ b/projects/geometry/101_color_cube_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(101_color_cube_vulkan)
 

--- a/projects/geometry/102_cornell_box_d3d12/CMakeLists.txt
+++ b/projects/geometry/102_cornell_box_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(102_cornell_box_d3d12)
 

--- a/projects/geometry/102_cornell_box_metal/CMakeLists.txt
+++ b/projects/geometry/102_cornell_box_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(102_cornell_box_metal)
 

--- a/projects/geometry/102_cornell_box_vulkan/CMakeLists.txt
+++ b/projects/geometry/102_cornell_box_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(102_cornell_box_vulkan)
 

--- a/projects/geometry/103_cone_d3d12/CMakeLists.txt
+++ b/projects/geometry/103_cone_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(103_cone_d3d12)
 

--- a/projects/geometry/103_cone_metal/CMakeLists.txt
+++ b/projects/geometry/103_cone_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(103_cone_metal)
 

--- a/projects/geometry/103_cone_vulkan/CMakeLists.txt
+++ b/projects/geometry/103_cone_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(103_cone_vulkan)
 

--- a/projects/geometry/104_debug_tbn_d3d12/CMakeLists.txt
+++ b/projects/geometry/104_debug_tbn_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(104_debug_tbn_d3d12)
 

--- a/projects/geometry/104_debug_tbn_metal/CMakeLists.txt
+++ b/projects/geometry/104_debug_tbn_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(104_debug_tbn_metal)
 

--- a/projects/geometry/104_debug_tbn_vulkan/CMakeLists.txt
+++ b/projects/geometry/104_debug_tbn_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(104_debug_tbn_vulkan)
 

--- a/projects/geometry/CMakeLists.txt
+++ b/projects/geometry/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # ------------------------------------------------------------------------------
 # Configure directories

--- a/projects/io/401_gltf_basic_geo_d3d12/CMakeLists.txt
+++ b/projects/io/401_gltf_basic_geo_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(401_gltf_basic_geo_d3d12)
 

--- a/projects/io/401_gltf_basic_geo_vulkan/CMakeLists.txt
+++ b/projects/io/401_gltf_basic_geo_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(401_gltf_basic_geo_vulkan)
 

--- a/projects/io/402_gltf_basic_texture_d3d12/CMakeLists.txt
+++ b/projects/io/402_gltf_basic_texture_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(402_gltf_basic_texture_d3d12)
 

--- a/projects/io/402_gltf_basic_texture_vulkan/CMakeLists.txt
+++ b/projects/io/402_gltf_basic_texture_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(402_gltf_basic_texture_vulkan)
 

--- a/projects/io/403_gltf_basic_material_d3d12/CMakeLists.txt
+++ b/projects/io/403_gltf_basic_material_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(403_gltf_basic_material_d3d12)
 

--- a/projects/io/403_gltf_basic_material_vulkan/CMakeLists.txt
+++ b/projects/io/403_gltf_basic_material_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(403_gltf_basic_material_vulkan)
 

--- a/projects/io/404_gltf_basic_material_texture_d3d12/CMakeLists.txt
+++ b/projects/io/404_gltf_basic_material_texture_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(404_gltf_basic_material_texture_d3d12)
 

--- a/projects/io/404_gltf_basic_material_texture_vulkan/CMakeLists.txt
+++ b/projects/io/404_gltf_basic_material_texture_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(404_gltf_basic_material_texture_vulkan)
 

--- a/projects/io/405_gltf_full_material_test_d3d12/CMakeLists.txt
+++ b/projects/io/405_gltf_full_material_test_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(405_gltf_full_material_test_d3d12)
 

--- a/projects/io/405_gltf_full_material_test_vulkan/CMakeLists.txt
+++ b/projects/io/405_gltf_full_material_test_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(405_gltf_full_material_test_vulkan)
 

--- a/projects/io/CMakeLists.txt
+++ b/projects/io/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # ------------------------------------------------------------------------------
 # Configure directories

--- a/projects/misc/gen_sphereflake_coords/CMakeLists.txt
+++ b/projects/misc/gen_sphereflake_coords/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(gen_sphereflake_coords)
 

--- a/projects/misc/gltf_d3d12/CMakeLists.txt
+++ b/projects/misc/gltf_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(gltf_d3d12)
 

--- a/projects/misc/ibl_brdf_lut/CMakeLists.txt
+++ b/projects/misc/ibl_brdf_lut/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(ibl_brdf_lut)
 

--- a/projects/misc/ibl_furnace/CMakeLists.txt
+++ b/projects/misc/ibl_furnace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(ibl_furnace)
 

--- a/projects/misc/ibl_prefilter_env/CMakeLists.txt
+++ b/projects/misc/ibl_prefilter_env/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(ibl_prefilter_env)
 

--- a/projects/misc/imgui_d3d12/CMakeLists.txt
+++ b/projects/misc/imgui_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(test_app_imgui_d3d12)
 

--- a/projects/misc/normal_map_convert/CMakeLists.txt
+++ b/projects/misc/normal_map_convert/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(normal_map_convert)
 

--- a/projects/misc/raygen/CMakeLists.txt
+++ b/projects/misc/raygen/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(raygen)
 

--- a/projects/misc/sampling_vis/CMakeLists.txt
+++ b/projects/misc/sampling_vis/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(sampling_vis)
 

--- a/projects/misc/window_events/CMakeLists.txt
+++ b/projects/misc/window_events/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(window_events)
 

--- a/projects/pbr/201_pbr_spheres_d3d12/CMakeLists.txt
+++ b/projects/pbr/201_pbr_spheres_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(201_pbr_spheres_d3d12)
 

--- a/projects/pbr/201_pbr_spheres_metal/CMakeLists.txt
+++ b/projects/pbr/201_pbr_spheres_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(201_pbr_spheres_metal)
 

--- a/projects/pbr/201_pbr_spheres_vulkan/CMakeLists.txt
+++ b/projects/pbr/201_pbr_spheres_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(201_pbr_spheres_vulkan)
 

--- a/projects/pbr/202_pbr_camera_d3d12/CMakeLists.txt
+++ b/projects/pbr/202_pbr_camera_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(202_pbr_camera_d3d12)
 

--- a/projects/pbr/202_pbr_camera_metal/CMakeLists.txt
+++ b/projects/pbr/202_pbr_camera_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(202_pbr_camera_metal)
 

--- a/projects/pbr/202_pbr_camera_vulkan/CMakeLists.txt
+++ b/projects/pbr/202_pbr_camera_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(202_pbr_camera_vulkan)
 

--- a/projects/pbr/203_pbr_align_d3d12/CMakeLists.txt
+++ b/projects/pbr/203_pbr_align_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(203_pbr_align_d3d12)
 

--- a/projects/pbr/203_pbr_align_metal/CMakeLists.txt
+++ b/projects/pbr/203_pbr_align_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(203_pbr_align_metal)
 

--- a/projects/pbr/203_pbr_align_vulkan/CMakeLists.txt
+++ b/projects/pbr/203_pbr_align_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(203_pbr_align_vulkan)
 

--- a/projects/pbr/251_pbr_explorer_d3d12/CMakeLists.txt
+++ b/projects/pbr/251_pbr_explorer_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(251_pbr_explorer_d3d12)
 

--- a/projects/pbr/251_pbr_explorer_metal/CMakeLists.txt
+++ b/projects/pbr/251_pbr_explorer_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(251_pbr_explorer_metal)
 

--- a/projects/pbr/251_pbr_explorer_vulkan/CMakeLists.txt
+++ b/projects/pbr/251_pbr_explorer_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(251_pbr_explorer_vulkan)
 

--- a/projects/pbr/252_pbr_material_properties_d3d12/CMakeLists.txt
+++ b/projects/pbr/252_pbr_material_properties_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(252_pbr_material_properties_d3d12)
 

--- a/projects/pbr/252_pbr_material_properties_metal/CMakeLists.txt
+++ b/projects/pbr/252_pbr_material_properties_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(252_pbr_material_properties_metal)
 

--- a/projects/pbr/252_pbr_material_properties_vulkan/CMakeLists.txt
+++ b/projects/pbr/252_pbr_material_properties_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(252_pbr_material_properties_vulkan)
 

--- a/projects/pbr/253_pbr_material_textures_d3d12/CMakeLists.txt
+++ b/projects/pbr/253_pbr_material_textures_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(253_pbr_material_textures_d3d12)
 

--- a/projects/pbr/253_pbr_material_textures_metal/CMakeLists.txt
+++ b/projects/pbr/253_pbr_material_textures_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(253_pbr_material_textures_metal)
 

--- a/projects/pbr/253_pbr_material_textures_vulkan/CMakeLists.txt
+++ b/projects/pbr/253_pbr_material_textures_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(253_pbr_material_textures_vulkan)
 

--- a/projects/pbr/CMakeLists.txt
+++ b/projects/pbr/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # ------------------------------------------------------------------------------
 # Configure directories

--- a/projects/raytracing/000_raygen_uv_d3d12/CMakeLists.txt
+++ b/projects/raytracing/000_raygen_uv_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(000_raygen_uv_d3d12)
 

--- a/projects/raytracing/000_raygen_uv_metal/CMakeLists.txt
+++ b/projects/raytracing/000_raygen_uv_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(000_raygen_uv_metal)
 

--- a/projects/raytracing/000_raygen_uv_vulkan/CMakeLists.txt
+++ b/projects/raytracing/000_raygen_uv_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(000_raygen_uv_vulkan)
 

--- a/projects/raytracing/001_raytracing_basic_d3d12/CMakeLists.txt
+++ b/projects/raytracing/001_raytracing_basic_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(001_raytracing_basic_d3d12)
 

--- a/projects/raytracing/001_raytracing_basic_vulkan/CMakeLists.txt
+++ b/projects/raytracing/001_raytracing_basic_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(001_raytracing_basic_vulkan)
 

--- a/projects/raytracing/002_basic_procedural_d3d12/CMakeLists.txt
+++ b/projects/raytracing/002_basic_procedural_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(002_basic_procedural_d3d12)
 

--- a/projects/raytracing/002_basic_procedural_vulkan/CMakeLists.txt
+++ b/projects/raytracing/002_basic_procedural_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(002_basic_procedural_vulkan)
 

--- a/projects/raytracing/003_sphereflake_d3d12/CMakeLists.txt
+++ b/projects/raytracing/003_sphereflake_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(003_sphereflake_d3d12)
 

--- a/projects/raytracing/003_sphereflake_vulkan/CMakeLists.txt
+++ b/projects/raytracing/003_sphereflake_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(003_sphereflake_vulkan)
 

--- a/projects/raytracing/004_basic_reflection_d3d12/CMakeLists.txt
+++ b/projects/raytracing/004_basic_reflection_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(004_basic_reflection_d3d12)
 

--- a/projects/raytracing/004_basic_reflection_vulkan/CMakeLists.txt
+++ b/projects/raytracing/004_basic_reflection_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(004_basic_reflection_vulkan)
 

--- a/projects/raytracing/005_basic_shadow_d3d12/CMakeLists.txt
+++ b/projects/raytracing/005_basic_shadow_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(005_basic_shadow_d3d12)
 

--- a/projects/raytracing/005_basic_shadow_vulkan/CMakeLists.txt
+++ b/projects/raytracing/005_basic_shadow_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(005_basic_shadow_vulkan)
 

--- a/projects/raytracing/006_basic_shadow_dynamic_d3d12/CMakeLists.txt
+++ b/projects/raytracing/006_basic_shadow_dynamic_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(006_basic_shadow_dynamic_d3d12)
 

--- a/projects/raytracing/006_basic_shadow_dynamic_vulkan/CMakeLists.txt
+++ b/projects/raytracing/006_basic_shadow_dynamic_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(006_basic_shadow_dynamic_vulkan)
 

--- a/projects/raytracing/021_raytracing_triangles_d3d12/CMakeLists.txt
+++ b/projects/raytracing/021_raytracing_triangles_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(021_raytracing_triangles_d3d12)
 

--- a/projects/raytracing/021_raytracing_triangles_vulkan/CMakeLists.txt
+++ b/projects/raytracing/021_raytracing_triangles_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(021_raytracing_triangles_vulkan)
 

--- a/projects/raytracing/022_raytracing_multi_geo_d3d12/CMakeLists.txt
+++ b/projects/raytracing/022_raytracing_multi_geo_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(022_raytracing_multi_geo_d3d12)
 

--- a/projects/raytracing/022_raytracing_multi_geo_vulkan/CMakeLists.txt
+++ b/projects/raytracing/022_raytracing_multi_geo_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(022_raytracing_multi_geo_vulkan)
 

--- a/projects/raytracing/023_raytracing_multi_instance_d3d12/CMakeLists.txt
+++ b/projects/raytracing/023_raytracing_multi_instance_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(023_raytracing_multi_instance_d3d12)
 

--- a/projects/raytracing/023_raytracing_multi_instance_vulkan/CMakeLists.txt
+++ b/projects/raytracing/023_raytracing_multi_instance_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(023_raytracing_multi_instance_vulkan)
 

--- a/projects/raytracing/024_raytracing_pbr_spheres_d3d12/CMakeLists.txt
+++ b/projects/raytracing/024_raytracing_pbr_spheres_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(024_raytracing_pbr_spheres_d3d12)
 

--- a/projects/raytracing/024_raytracing_pbr_spheres_vulkan/CMakeLists.txt
+++ b/projects/raytracing/024_raytracing_pbr_spheres_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(024_raytracing_pbr_spheres_vulkan)
 

--- a/projects/raytracing/025_raytracing_refract_d3d12/CMakeLists.txt
+++ b/projects/raytracing/025_raytracing_refract_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(025_raytracing_refract_d3d12)
 

--- a/projects/raytracing/025_raytracing_refract_vulkan/CMakeLists.txt
+++ b/projects/raytracing/025_raytracing_refract_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(025_raytracing_refract_vulkan)
 

--- a/projects/raytracing/030_raytracing_path_trace_d3d12/CMakeLists.txt
+++ b/projects/raytracing/030_raytracing_path_trace_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(030_raytracing_path_trace_d3d12)
 

--- a/projects/raytracing/030_raytracing_path_trace_vulkan/CMakeLists.txt
+++ b/projects/raytracing/030_raytracing_path_trace_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(030_raytracing_path_trace_vulkan)
 

--- a/projects/raytracing/030_raytracing_path_trace_vulkan_bof/CMakeLists.txt
+++ b/projects/raytracing/030_raytracing_path_trace_vulkan_bof/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(030_raytracing_path_trace_vulkan_bof)
 

--- a/projects/raytracing/031_raytracing_path_trace_pbr_d3d12/CMakeLists.txt
+++ b/projects/raytracing/031_raytracing_path_trace_pbr_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(031_raytracing_path_trace_pbr_d3d12)
 

--- a/projects/raytracing/031_raytracing_path_trace_pbr_vulkan/CMakeLists.txt
+++ b/projects/raytracing/031_raytracing_path_trace_pbr_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(031_raytracing_path_trace_pbr_vulkan)
 

--- a/projects/raytracing/CMakeLists.txt
+++ b/projects/raytracing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # ------------------------------------------------------------------------------
 # Configure directories

--- a/projects/texture/301_textured_cube_d3d12/CMakeLists.txt
+++ b/projects/texture/301_textured_cube_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(301_textured_cube_d3d12)
 

--- a/projects/texture/301_textured_cube_metal/CMakeLists.txt
+++ b/projects/texture/301_textured_cube_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(301_textured_cube_metal)
 

--- a/projects/texture/301_textured_cube_vulkan/CMakeLists.txt
+++ b/projects/texture/301_textured_cube_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(301_textured_cube_vulkan)
 

--- a/projects/texture/302_lambert_textured_cube_d3d12/CMakeLists.txt
+++ b/projects/texture/302_lambert_textured_cube_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(302_lambert_textured_cube_d3d12)
 

--- a/projects/texture/302_lambert_textured_cube_metal/CMakeLists.txt
+++ b/projects/texture/302_lambert_textured_cube_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(302_textured_cube_metal)
 

--- a/projects/texture/302_lambert_textured_cube_vulkan/CMakeLists.txt
+++ b/projects/texture/302_lambert_textured_cube_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(302_lambert_textured_cube_vulkan)
 

--- a/projects/texture/303_phong_textured_cube_d3d12/CMakeLists.txt
+++ b/projects/texture/303_phong_textured_cube_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(303_phong_textured_cube_d3d12)
 

--- a/projects/texture/303_phong_textured_cube_metal/CMakeLists.txt
+++ b/projects/texture/303_phong_textured_cube_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(303_phong_textured_cube_metal)
 

--- a/projects/texture/303_phong_textured_cube_vulkan/CMakeLists.txt
+++ b/projects/texture/303_phong_textured_cube_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(303_phong_textured_cube_vulkan)
 

--- a/projects/texture/304_normal_map_d3d12/CMakeLists.txt
+++ b/projects/texture/304_normal_map_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(304_normal_map_d3d12)
 

--- a/projects/texture/304_normal_map_metal/CMakeLists.txt
+++ b/projects/texture/304_normal_map_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(304_normal_map_metal)
 

--- a/projects/texture/304_normal_map_vulkan/CMakeLists.txt
+++ b/projects/texture/304_normal_map_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(304_normal_map_vulkan)
 

--- a/projects/texture/305_normal_map_explorer_d3d12/CMakeLists.txt
+++ b/projects/texture/305_normal_map_explorer_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(305_normal_map_explorer_d3d12)
 

--- a/projects/texture/305_normal_map_explorer_metal/CMakeLists.txt
+++ b/projects/texture/305_normal_map_explorer_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(305_normal_map_explorer_metal)
 

--- a/projects/texture/305_normal_map_explorer_vulkan/CMakeLists.txt
+++ b/projects/texture/305_normal_map_explorer_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(305_normal_map_explorer_vulkan)
 

--- a/projects/texture/306_parallax_occlusion_map_d3d12/CMakeLists.txt
+++ b/projects/texture/306_parallax_occlusion_map_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(306_parallax_occlusion_map_d3d12)
 

--- a/projects/texture/306_parallax_occlusion_map_metal/CMakeLists.txt
+++ b/projects/texture/306_parallax_occlusion_map_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(306_parallax_occlusion_map_metal)
 

--- a/projects/texture/306_parallax_occlusion_map_vulkan/CMakeLists.txt
+++ b/projects/texture/306_parallax_occlusion_map_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(306_parallax_occlusion_map_vulkan)
 

--- a/projects/texture/307_parallax_occlusion_map_explorer_d3d12/CMakeLists.txt
+++ b/projects/texture/307_parallax_occlusion_map_explorer_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(307_parallax_occlusion_map_explorer_d3d12)
 

--- a/projects/texture/307_parallax_occlusion_map_explorer_metal/CMakeLists.txt
+++ b/projects/texture/307_parallax_occlusion_map_explorer_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(307_parallax_occlusion_map_explorer_metal)
 

--- a/projects/texture/307_parallax_occlusion_map_explorer_vulkan/CMakeLists.txt
+++ b/projects/texture/307_parallax_occlusion_map_explorer_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(307_parallax_occlusion_map_explorer_vulkan)
 

--- a/projects/texture/308_normal_map_vs_pom_d3d12/CMakeLists.txt
+++ b/projects/texture/308_normal_map_vs_pom_d3d12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(308_normal_map_vs_pom_d3d12)
 

--- a/projects/texture/308_normal_map_vs_pom_metal/CMakeLists.txt
+++ b/projects/texture/308_normal_map_vs_pom_metal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(308_normal_map_vs_pom_metal)
 

--- a/projects/texture/308_normal_map_vs_pom_vulkan/CMakeLists.txt
+++ b/projects/texture/308_normal_map_vs_pom_vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(308_normal_map_vs_pom_vulkan)
 

--- a/projects/texture/CMakeLists.txt
+++ b/projects/texture/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # ------------------------------------------------------------------------------
 # Configure directories


### PR DESCRIPTION
Due to an update of my local CMake, I'm changing the minimum version required to 3.5 (due to a deprecation that's coming up). I modified every CMakeLists.txt file that wasn't under the third_party directory.