### PR TITLE
Switch staging buffer back to managed resource

### DIFF
--- a/projects/common/mtl_renderer.cpp
+++ b/projects/common/mtl_renderer.cpp
@@ -229,7 +229,7 @@ NS::Error* CreateBuffer(
     const void*    pSrcData,
     MetalBuffer*   pBuffer)
 {
-    return CreateBuffer(pRenderer, srcSize, pSrcData, MTL::ResourceStorageModeShared, pBuffer);
+    return CreateBuffer(pRenderer, srcSize, pSrcData, MTL::ResourceStorageModeManaged, pBuffer);
 
 /*
     pBuffer->Buffer = NS::TransferPtr(pRenderer->Device->newBuffer(srcSize, MTL::ResourceStorageModeManaged));


### PR DESCRIPTION
The io examples were crashing due to the following error:

-[MTLDebugBuffer didModifyRange:]:485: failed assertion
    `didModifyRange: only applies when resourceOptions(0x0) & MTLResourceStorageModeMask(0xf0) == MTLResourceStorageModeManaged(0x10).
    NOT MTLResourceStorageModeShared'

So that's why I'm switching the creation back to a managed resource. It's possible that this is the "wrong" fix, but it's what we had working originally.

Closes #106 