### PR TITLE
Rename Get Window functions to GetNativeWindowHandle

### DIFF
--- a/projects/common/window.cpp
+++ b/projects/common/window.cpp
@@ -677,14 +677,14 @@ void GrexWindow::ImGuiRenderDrawData(MetalRenderer* pRenderer, MTL::CommandBuffe
 // Platform functions
 // =============================================================================
 #if defined(WIN32)
-HWND GrexWindow::GetHWND() const
+HWND GrexWindow::GetNativeWindowHandle() const
 {
     return glfwGetWin32Window(mWindow);
 }
 #endif
 
 #if defined(__APPLE__)
-void* GrexWindow::GetNativeWindow() const
+void* GrexWindow::GetNativeWindowHandle() const
 {
    return glfwGetCocoaWindow(mWindow);
 }

--- a/projects/common/window.h
+++ b/projects/common/window.h
@@ -65,11 +65,11 @@ public:
     float       GetAspectRatio() const { return static_cast<float>(mWidth) / static_cast<float>(mHeight); }
 
 #if defined(WIN32)
-    HWND GetHWND() const;
+    HWND GetNativeWindowHandle() const;
 #endif
 
 #if defined(__APPLE__)
-    void* GetNativeWindow() const;
+    void* GetNativeWindowHandle() const;
 #endif
 
 #if defined(GREX_ENABLE_VULKAN)

--- a/projects/geometry/101_color_cube_d3d12/101_color_cube_d3d12.cpp
+++ b/projects/geometry/101_color_cube_d3d12/101_color_cube_d3d12.cpp
@@ -148,7 +148,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/101_color_cube_metal/101_color_cube_metal.cpp
+++ b/projects/geometry/101_color_cube_metal/101_color_cube_metal.cpp
@@ -157,7 +157,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/101_color_cube_vulkan/101_color_cube_vulkan.cpp
+++ b/projects/geometry/101_color_cube_vulkan/101_color_cube_vulkan.cpp
@@ -194,7 +194,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/102_cornell_box_d3d12/102_cornell_box_d3d12.cpp
+++ b/projects/geometry/102_cornell_box_d3d12/102_cornell_box_d3d12.cpp
@@ -194,7 +194,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/102_cornell_box_metal/102_cornell_box_metal.cpp
+++ b/projects/geometry/102_cornell_box_metal/102_cornell_box_metal.cpp
@@ -206,7 +206,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/102_cornell_box_vulkan/102_cornell_box_vulkan.cpp
+++ b/projects/geometry/102_cornell_box_vulkan/102_cornell_box_vulkan.cpp
@@ -256,7 +256,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/103_cone_d3d12/103_cone_d3d12.cpp
+++ b/projects/geometry/103_cone_d3d12/103_cone_d3d12.cpp
@@ -174,7 +174,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/103_cone_metal/103_cone_metal.cpp
+++ b/projects/geometry/103_cone_metal/103_cone_metal.cpp
@@ -183,7 +183,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/103_cone_vulkan/103_cone_vulkan.cpp
+++ b/projects/geometry/103_cone_vulkan/103_cone_vulkan.cpp
@@ -213,7 +213,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/104_debug_tbn_d3d12/104_debug_tbn_d3d12.cpp
+++ b/projects/geometry/104_debug_tbn_d3d12/104_debug_tbn_d3d12.cpp
@@ -216,7 +216,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/104_debug_tbn_metal/104_debug_tbn_metal.cpp
+++ b/projects/geometry/104_debug_tbn_metal/104_debug_tbn_metal.cpp
@@ -225,7 +225,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/104_debug_tbn_vulkan/104_debug_tbn_vulkan.cpp
+++ b/projects/geometry/104_debug_tbn_vulkan/104_debug_tbn_vulkan.cpp
@@ -256,7 +256,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/110_mesh_shader_triangle_d3d12/110_mesh_shader_triangle_d3d12.cpp
+++ b/projects/geometry/110_mesh_shader_triangle_d3d12/110_mesh_shader_triangle_d3d12.cpp
@@ -207,7 +207,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/110_mesh_shader_triangle_metal/110_mesh_shader_triangle_metal.cpp
+++ b/projects/geometry/110_mesh_shader_triangle_metal/110_mesh_shader_triangle_metal.cpp
@@ -169,7 +169,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/111_mesh_shader_meshlets_d3d12/111_mesh_shader_meshlets_d3d12.cpp
+++ b/projects/geometry/111_mesh_shader_meshlets_d3d12/111_mesh_shader_meshlets_d3d12.cpp
@@ -267,7 +267,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/111_mesh_shader_meshlets_metal/111_mesh_shader_meshlets_metal.cpp
+++ b/projects/geometry/111_mesh_shader_meshlets_metal/111_mesh_shader_meshlets_metal.cpp
@@ -242,7 +242,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/111_mesh_shader_meshlets_vulkan/111_mesh_shader_meshlets_vulkan.cpp
+++ b/projects/geometry/111_mesh_shader_meshlets_vulkan/111_mesh_shader_meshlets_vulkan.cpp
@@ -251,7 +251,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/112_mesh_shader_amplification_d3d12/112_mesh_shader_amplification_d3d12.cpp
+++ b/projects/geometry/112_mesh_shader_amplification_d3d12/112_mesh_shader_amplification_d3d12.cpp
@@ -280,7 +280,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/112_mesh_shader_amplification_metal/112_mesh_shader_amplification_metal.cpp
+++ b/projects/geometry/112_mesh_shader_amplification_metal/112_mesh_shader_amplification_metal.cpp
@@ -245,7 +245,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/113_mesh_shader_instancing_d3d12/113_mesh_shader_instancing_d3d12.cpp
+++ b/projects/geometry/113_mesh_shader_instancing_d3d12/113_mesh_shader_instancing_d3d12.cpp
@@ -289,7 +289,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/113_mesh_shader_instancing_metal/113_mesh_shader_instancing_metal.cpp
+++ b/projects/geometry/113_mesh_shader_instancing_metal/113_mesh_shader_instancing_metal.cpp
@@ -247,7 +247,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/113_mesh_shader_instancing_vulkan/113_mesh_shader_instancing_vulkan.cpp
+++ b/projects/geometry/113_mesh_shader_instancing_vulkan/113_mesh_shader_instancing_vulkan.cpp
@@ -262,7 +262,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/114_mesh_shader_culling_d3d12/114_mesh_shader_culling_d3d12.cpp
+++ b/projects/geometry/114_mesh_shader_culling_d3d12/114_mesh_shader_culling_d3d12.cpp
@@ -347,7 +347,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/114_mesh_shader_culling_metal/114_mesh_shader_culling_metal.cpp
+++ b/projects/geometry/114_mesh_shader_culling_metal/114_mesh_shader_culling_metal.cpp
@@ -367,7 +367,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/114_mesh_shader_culling_vulkan/114_mesh_shader_culling_vulkan.cpp
+++ b/projects/geometry/114_mesh_shader_culling_vulkan/114_mesh_shader_culling_vulkan.cpp
@@ -380,7 +380,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/115_mesh_shader_lod_d3d12/115_mesh_shader_lod_d3d12.cpp
+++ b/projects/geometry/115_mesh_shader_lod_d3d12/115_mesh_shader_lod_d3d12.cpp
@@ -370,7 +370,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/115_mesh_shader_lod_metal/115_mesh_shader_lod_metal.cpp
+++ b/projects/geometry/115_mesh_shader_lod_metal/115_mesh_shader_lod_metal.cpp
@@ -394,7 +394,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/115_mesh_shader_lod_vulkan/115_mesh_shader_lod_vulkan.cpp
+++ b/projects/geometry/115_mesh_shader_lod_vulkan/115_mesh_shader_lod_vulkan.cpp
@@ -402,7 +402,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/116_mesh_shader_calc_lod_d3d12/116_mesh_shader_calc_lod_d3d12.cpp
+++ b/projects/geometry/116_mesh_shader_calc_lod_d3d12/116_mesh_shader_calc_lod_d3d12.cpp
@@ -380,7 +380,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/116_mesh_shader_calc_lod_metal/116_mesh_shader_calc_lod_metal.cpp
+++ b/projects/geometry/116_mesh_shader_calc_lod_metal/116_mesh_shader_calc_lod_metal.cpp
@@ -401,7 +401,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/116_mesh_shader_calc_lod_vulkan/116_mesh_shader_calc_lod_vulkan.cpp
+++ b/projects/geometry/116_mesh_shader_calc_lod_vulkan/116_mesh_shader_calc_lod_vulkan.cpp
@@ -410,7 +410,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/117_mesh_shader_cull_lod_d3d12/117_mesh_shader_cull_lod_d3d12.cpp
+++ b/projects/geometry/117_mesh_shader_cull_lod_d3d12/117_mesh_shader_cull_lod_d3d12.cpp
@@ -464,7 +464,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/117_mesh_shader_cull_lod_metal/117_mesh_shader_cull_lod_metal.cpp
+++ b/projects/geometry/117_mesh_shader_cull_lod_metal/117_mesh_shader_cull_lod_metal.cpp
@@ -485,7 +485,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/117_mesh_shader_cull_lod_vulkan/117_mesh_shader_cull_lod_vulkan.cpp
+++ b/projects/geometry/117_mesh_shader_cull_lod_vulkan/117_mesh_shader_cull_lod_vulkan.cpp
@@ -493,7 +493,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/118_mesh_shader_vertex_attrs_d3d12/118_mesh_shader_vertex_attrs_d3d12.cpp
+++ b/projects/geometry/118_mesh_shader_vertex_attrs_d3d12/118_mesh_shader_vertex_attrs_d3d12.cpp
@@ -322,7 +322,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/118_mesh_shader_vertex_attrs_metal/118_mesh_shader_vertex_attrs_metal.cpp
+++ b/projects/geometry/118_mesh_shader_vertex_attrs_metal/118_mesh_shader_vertex_attrs_metal.cpp
@@ -286,7 +286,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/geometry/118_mesh_shader_vertex_attrs_vulkan/118_mesh_shader_vertex_attrs_vulkan.cpp
+++ b/projects/geometry/118_mesh_shader_vertex_attrs_vulkan/118_mesh_shader_vertex_attrs_vulkan.cpp
@@ -300,7 +300,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/119_mesh_shader_vertex_bary_d3d12/119_mesh_shader_vertex_bary_d3d12.cpp
+++ b/projects/geometry/119_mesh_shader_vertex_bary_d3d12/119_mesh_shader_vertex_bary_d3d12.cpp
@@ -322,7 +322,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/geometry/119_mesh_shader_vertex_bary_vulkan/119_mesh_shader_vertex_bary_vulkan.cpp
+++ b/projects/geometry/119_mesh_shader_vertex_bary_vulkan/119_mesh_shader_vertex_bary_vulkan.cpp
@@ -306,7 +306,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/401_gltf_basic_geo_d3d12/401_gltf_basic_geo_d3d12.cpp
+++ b/projects/io/401_gltf_basic_geo_d3d12/401_gltf_basic_geo_d3d12.cpp
@@ -246,7 +246,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/401_gltf_basic_geo_metal/401_gltf_basic_geo_metal.cpp
+++ b/projects/io/401_gltf_basic_geo_metal/401_gltf_basic_geo_metal.cpp
@@ -277,7 +277,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/401_gltf_basic_geo_vulkan/401_gltf_basic_geo_vulkan.cpp
+++ b/projects/io/401_gltf_basic_geo_vulkan/401_gltf_basic_geo_vulkan.cpp
@@ -305,7 +305,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/402_gltf_basic_texture_d3d12/402_gltf_basic_texture_d3d12.cpp
+++ b/projects/io/402_gltf_basic_texture_d3d12/402_gltf_basic_texture_d3d12.cpp
@@ -246,7 +246,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/402_gltf_basic_texture_metal/402_gltf_basic_texture_metal.cpp
+++ b/projects/io/402_gltf_basic_texture_metal/402_gltf_basic_texture_metal.cpp
@@ -277,7 +277,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/402_gltf_basic_texture_vulkan/402_gltf_basic_texture_vulkan.cpp
+++ b/projects/io/402_gltf_basic_texture_vulkan/402_gltf_basic_texture_vulkan.cpp
@@ -306,7 +306,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/403_gltf_basic_material_d3d12/403_gltf_basic_material_d3d12.cpp
+++ b/projects/io/403_gltf_basic_material_d3d12/403_gltf_basic_material_d3d12.cpp
@@ -246,7 +246,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/403_gltf_basic_material_metal/403_gltf_basic_material_metal.cpp
+++ b/projects/io/403_gltf_basic_material_metal/403_gltf_basic_material_metal.cpp
@@ -277,7 +277,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/403_gltf_basic_material_vulkan/403_gltf_basic_material_vulkan.cpp
+++ b/projects/io/403_gltf_basic_material_vulkan/403_gltf_basic_material_vulkan.cpp
@@ -306,7 +306,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/404_gltf_basic_material_texture_d3d12/404_gltf_basic_material_texture_d3d12.cpp
+++ b/projects/io/404_gltf_basic_material_texture_d3d12/404_gltf_basic_material_texture_d3d12.cpp
@@ -246,7 +246,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/404_gltf_basic_material_texture_metal/404_gltf_basic_material_texture_metal.cpp
+++ b/projects/io/404_gltf_basic_material_texture_metal/404_gltf_basic_material_texture_metal.cpp
@@ -281,7 +281,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/404_gltf_basic_material_texture_vulkan/404_gltf_basic_material_texture_vulkan.cpp
+++ b/projects/io/404_gltf_basic_material_texture_vulkan/404_gltf_basic_material_texture_vulkan.cpp
@@ -305,7 +305,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/405_gltf_full_material_test_d3d12/405_gltf_full_material_test_d3d12.cpp
+++ b/projects/io/405_gltf_full_material_test_d3d12/405_gltf_full_material_test_d3d12.cpp
@@ -332,7 +332,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/io/405_gltf_full_material_test_vulkan/405_gltf_full_material_test_vulkan.cpp
+++ b/projects/io/405_gltf_full_material_test_vulkan/405_gltf_full_material_test_vulkan.cpp
@@ -513,7 +513,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/misc/frustum_planes/frustum_planes.cpp
+++ b/projects/misc/frustum_planes/frustum_planes.cpp
@@ -161,7 +161,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/misc/gltf_d3d12/gltf_d3d12.cpp
+++ b/projects/misc/gltf_d3d12/gltf_d3d12.cpp
@@ -332,7 +332,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/misc/imgui_d3d12/test_app_imgui_d3d12.cpp
+++ b/projects/misc/imgui_d3d12/test_app_imgui_d3d12.cpp
@@ -117,7 +117,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/misc/sampling_vis/sampling_vis.cpp
+++ b/projects/misc/sampling_vis/sampling_vis.cpp
@@ -185,7 +185,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/201_pbr_spheres_d3d12/201_pbr_spheres_d3d12.cpp
+++ b/projects/pbr/201_pbr_spheres_d3d12/201_pbr_spheres_d3d12.cpp
@@ -300,7 +300,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/201_pbr_spheres_metal/201_pbr_spheres_metal.cpp
+++ b/projects/pbr/201_pbr_spheres_metal/201_pbr_spheres_metal.cpp
@@ -275,7 +275,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/201_pbr_spheres_vulkan/201_pbr_spheres_vulkan.cpp
+++ b/projects/pbr/201_pbr_spheres_vulkan/201_pbr_spheres_vulkan.cpp
@@ -367,7 +367,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/202_pbr_camera_d3d12/202_pbr_camera_d3d12.cpp
+++ b/projects/pbr/202_pbr_camera_d3d12/202_pbr_camera_d3d12.cpp
@@ -390,7 +390,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/202_pbr_camera_metal/202_pbr_camera_metal.cpp
+++ b/projects/pbr/202_pbr_camera_metal/202_pbr_camera_metal.cpp
@@ -380,7 +380,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/202_pbr_camera_vulkan/202_pbr_camera_vulkan.cpp
+++ b/projects/pbr/202_pbr_camera_vulkan/202_pbr_camera_vulkan.cpp
@@ -447,7 +447,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/pbr/203_pbr_align_d3d12/203_pbr_align_d3d12.cpp
+++ b/projects/pbr/203_pbr_align_d3d12/203_pbr_align_d3d12.cpp
@@ -300,7 +300,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/203_pbr_align_metal/203_pbr_align_metal.cpp
+++ b/projects/pbr/203_pbr_align_metal/203_pbr_align_metal.cpp
@@ -275,7 +275,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/203_pbr_align_vulkan/203_pbr_align_vulkan.cpp
+++ b/projects/pbr/203_pbr_align_vulkan/203_pbr_align_vulkan.cpp
@@ -374,7 +374,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/pbr/251_pbr_explorer_d3d12/251_pbr_explorer_d3d12.cpp
+++ b/projects/pbr/251_pbr_explorer_d3d12/251_pbr_explorer_d3d12.cpp
@@ -442,7 +442,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/251_pbr_explorer_metal/251_pbr_explorer_metal.cpp
+++ b/projects/pbr/251_pbr_explorer_metal/251_pbr_explorer_metal.cpp
@@ -423,7 +423,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/251_pbr_explorer_vulkan/251_pbr_explorer_vulkan.cpp
+++ b/projects/pbr/251_pbr_explorer_vulkan/251_pbr_explorer_vulkan.cpp
@@ -517,7 +517,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/pbr/252_pbr_material_properties_d3d12/252_pbr_material_properties_d3d12.cpp
+++ b/projects/pbr/252_pbr_material_properties_d3d12/252_pbr_material_properties_d3d12.cpp
@@ -364,7 +364,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/252_pbr_material_properties_metal/252_pbr_material_properties_metal.cpp
+++ b/projects/pbr/252_pbr_material_properties_metal/252_pbr_material_properties_metal.cpp
@@ -351,7 +351,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/252_pbr_material_properties_vulkan/252_pbr_material_properties_vulkan.cpp
+++ b/projects/pbr/252_pbr_material_properties_vulkan/252_pbr_material_properties_vulkan.cpp
@@ -328,7 +328,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/pbr/253_pbr_material_textures_d3d12/253_pbr_material_textures_d3d12.cpp
+++ b/projects/pbr/253_pbr_material_textures_d3d12/253_pbr_material_textures_d3d12.cpp
@@ -395,7 +395,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/253_pbr_material_textures_metal/253_pbr_material_textures_metal.cpp
+++ b/projects/pbr/253_pbr_material_textures_metal/253_pbr_material_textures_metal.cpp
@@ -401,7 +401,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/pbr/253_pbr_material_textures_vulkan/253_pbr_material_textures_vulkan.cpp
+++ b/projects/pbr/253_pbr_material_textures_vulkan/253_pbr_material_textures_vulkan.cpp
@@ -446,7 +446,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/000_raygen_uv_d3d12/000_raygen_uv_d3d12.cpp
+++ b/projects/raytracing/000_raygen_uv_d3d12/000_raygen_uv_d3d12.cpp
@@ -199,7 +199,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/000_raygen_uv_metal/000_raygen_uv_metal.cpp
+++ b/projects/raytracing/000_raygen_uv_metal/000_raygen_uv_metal.cpp
@@ -184,7 +184,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/000_raygen_uv_vulkan/000_raygen_uv_vulkan.cpp
+++ b/projects/raytracing/000_raygen_uv_vulkan/000_raygen_uv_vulkan.cpp
@@ -246,7 +246,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/001_raytracing_basic_d3d12/001_raytracing_basic_d3d12.cpp
+++ b/projects/raytracing/001_raytracing_basic_d3d12/001_raytracing_basic_d3d12.cpp
@@ -266,7 +266,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/001_raytracing_basic_metal/001_raytracing_basic_metal.cpp
+++ b/projects/raytracing/001_raytracing_basic_metal/001_raytracing_basic_metal.cpp
@@ -256,7 +256,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/001_raytracing_basic_vulkan/001_raytracing_basic_vulkan.cpp
+++ b/projects/raytracing/001_raytracing_basic_vulkan/001_raytracing_basic_vulkan.cpp
@@ -380,7 +380,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/002_basic_procedural_d3d12/002_basic_procedural_d3d12.cpp
+++ b/projects/raytracing/002_basic_procedural_d3d12/002_basic_procedural_d3d12.cpp
@@ -321,7 +321,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/002_basic_procedural_metal/002_basic_procedural_metal.cpp
+++ b/projects/raytracing/002_basic_procedural_metal/002_basic_procedural_metal.cpp
@@ -354,7 +354,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/002_basic_procedural_vulkan/002_basic_procedural_vulkan.cpp
+++ b/projects/raytracing/002_basic_procedural_vulkan/002_basic_procedural_vulkan.cpp
@@ -447,7 +447,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/003_sphereflake_d3d12/003_sphereflake_d3d12.cpp
+++ b/projects/raytracing/003_sphereflake_d3d12/003_sphereflake_d3d12.cpp
@@ -389,7 +389,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/003_sphereflake_metal/003_sphereflake_metal.cpp
+++ b/projects/raytracing/003_sphereflake_metal/003_sphereflake_metal.cpp
@@ -450,7 +450,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/003_sphereflake_vulkan/003_sphereflake_vulkan.cpp
+++ b/projects/raytracing/003_sphereflake_vulkan/003_sphereflake_vulkan.cpp
@@ -503,7 +503,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/004_basic_reflection_d3d12/004_basic_reflection_d3d12.cpp
+++ b/projects/raytracing/004_basic_reflection_d3d12/004_basic_reflection_d3d12.cpp
@@ -468,7 +468,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/004_basic_reflection_metal/004_basic_reflection_metal.cpp
+++ b/projects/raytracing/004_basic_reflection_metal/004_basic_reflection_metal.cpp
@@ -526,7 +526,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/004_basic_reflection_vulkan/004_basic_reflection_vulkan.cpp
+++ b/projects/raytracing/004_basic_reflection_vulkan/004_basic_reflection_vulkan.cpp
@@ -584,7 +584,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/005_basic_shadow_d3d12/005_basic_shadow_d3d12.cpp
+++ b/projects/raytracing/005_basic_shadow_d3d12/005_basic_shadow_d3d12.cpp
@@ -514,7 +514,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/005_basic_shadow_metal/005_basic_shadow_metal.cpp
+++ b/projects/raytracing/005_basic_shadow_metal/005_basic_shadow_metal.cpp
@@ -587,7 +587,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/005_basic_shadow_vulkan/005_basic_shadow_vulkan.cpp
+++ b/projects/raytracing/005_basic_shadow_vulkan/005_basic_shadow_vulkan.cpp
@@ -672,7 +672,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/006_basic_shadow_dynamic_d3d12/006_basic_shadow_dynamic_d3d12.cpp
+++ b/projects/raytracing/006_basic_shadow_dynamic_d3d12/006_basic_shadow_dynamic_d3d12.cpp
@@ -515,7 +515,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/006_basic_shadow_dynamic_metal/006_basic_shadow_dynamic_metal.cpp
+++ b/projects/raytracing/006_basic_shadow_dynamic_metal/006_basic_shadow_dynamic_metal.cpp
@@ -588,7 +588,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/006_basic_shadow_dynamic_vulkan/006_basic_shadow_dynamic_vulkan.cpp
+++ b/projects/raytracing/006_basic_shadow_dynamic_vulkan/006_basic_shadow_dynamic_vulkan.cpp
@@ -673,7 +673,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/021_raytracing_triangles_d3d12/021_raytracing_triangles_d3d12.cpp
+++ b/projects/raytracing/021_raytracing_triangles_d3d12/021_raytracing_triangles_d3d12.cpp
@@ -215,7 +215,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/021_raytracing_triangles_metal/021_raytracing_triangles_metal.cpp
+++ b/projects/raytracing/021_raytracing_triangles_metal/021_raytracing_triangles_metal.cpp
@@ -203,7 +203,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/021_raytracing_triangles_vulkan/021_raytracing_triangles_vulkan.cpp
+++ b/projects/raytracing/021_raytracing_triangles_vulkan/021_raytracing_triangles_vulkan.cpp
@@ -289,7 +289,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/022_raytracing_multi_geo_d3d12/022_raytracing_multi_geo_d3d12.cpp
+++ b/projects/raytracing/022_raytracing_multi_geo_d3d12/022_raytracing_multi_geo_d3d12.cpp
@@ -236,7 +236,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/022_raytracing_multi_geo_vulkan/022_raytracing_multi_geo_vulkan.cpp
+++ b/projects/raytracing/022_raytracing_multi_geo_vulkan/022_raytracing_multi_geo_vulkan.cpp
@@ -313,7 +313,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/023_raytracing_multi_instance_d3d12/023_raytracing_multi_instance_d3d12.cpp
+++ b/projects/raytracing/023_raytracing_multi_instance_d3d12/023_raytracing_multi_instance_d3d12.cpp
@@ -239,7 +239,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/023_raytracing_multi_instance_vulkan/023_raytracing_multi_instance_vulkan.cpp
+++ b/projects/raytracing/023_raytracing_multi_instance_vulkan/023_raytracing_multi_instance_vulkan.cpp
@@ -316,7 +316,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/024_raytracing_pbr_spheres_d3d12/024_raytracing_pbr_spheres_d3d12.cpp
+++ b/projects/raytracing/024_raytracing_pbr_spheres_d3d12/024_raytracing_pbr_spheres_d3d12.cpp
@@ -313,7 +313,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/024_raytracing_pbr_spheres_vulkan/024_raytracing_pbr_spheres_vulkan.cpp
+++ b/projects/raytracing/024_raytracing_pbr_spheres_vulkan/024_raytracing_pbr_spheres_vulkan.cpp
@@ -409,7 +409,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 3))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 3))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/025_raytracing_refract_d3d12/025_raytracing_refract_d3d12.cpp
+++ b/projects/raytracing/025_raytracing_refract_d3d12/025_raytracing_refract_d3d12.cpp
@@ -331,7 +331,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/025_raytracing_refract_vulkan/025_raytracing_refract_vulkan.cpp
+++ b/projects/raytracing/025_raytracing_refract_vulkan/025_raytracing_refract_vulkan.cpp
@@ -395,7 +395,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 3))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 3))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/030_raytracing_path_trace_d3d12/030_raytracing_path_trace_d3d12.cpp
+++ b/projects/raytracing/030_raytracing_path_trace_d3d12/030_raytracing_path_trace_d3d12.cpp
@@ -424,7 +424,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/030_raytracing_path_trace_metal/030_raytracing_path_trace_metal.cpp
+++ b/projects/raytracing/030_raytracing_path_trace_metal/030_raytracing_path_trace_metal.cpp
@@ -352,7 +352,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/030_raytracing_path_trace_vulkan/030_raytracing_path_trace_vulkan.cpp
+++ b/projects/raytracing/030_raytracing_path_trace_vulkan/030_raytracing_path_trace_vulkan.cpp
@@ -566,7 +566,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 3))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 3))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/030_raytracing_path_trace_vulkan_bof/030_raytracing_path_trace_vulkan_bof.cpp
+++ b/projects/raytracing/030_raytracing_path_trace_vulkan_bof/030_raytracing_path_trace_vulkan_bof.cpp
@@ -584,7 +584,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 3)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 3)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/031_raytracing_path_trace_pbr_d3d12/031_raytracing_path_trace_pbr_d3d12.cpp
+++ b/projects/raytracing/031_raytracing_path_trace_pbr_d3d12/031_raytracing_path_trace_pbr_d3d12.cpp
@@ -464,7 +464,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight())) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight())) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/raytracing/031_raytracing_path_trace_pbr_metal/031_raytracing_path_trace_pbr_metal.cpp
+++ b/projects/raytracing/031_raytracing_path_trace_pbr_metal/031_raytracing_path_trace_pbr_metal.cpp
@@ -441,7 +441,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/raytracing/031_raytracing_path_trace_pbr_vulkan/031_raytracing_path_trace_pbr_vulkan.cpp
+++ b/projects/raytracing/031_raytracing_path_trace_pbr_vulkan/031_raytracing_path_trace_pbr_vulkan.cpp
@@ -611,7 +611,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 3))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 3))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/301_textured_cube_d3d12/301_textured_cube_d3d12.cpp
+++ b/projects/texture/301_textured_cube_d3d12/301_textured_cube_d3d12.cpp
@@ -196,7 +196,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/texture/301_textured_cube_metal/301_textured_cube_metal.cpp
+++ b/projects/texture/301_textured_cube_metal/301_textured_cube_metal.cpp
@@ -175,7 +175,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/301_textured_cube_vulkan/301_textured_cube_vulkan.cpp
+++ b/projects/texture/301_textured_cube_vulkan/301_textured_cube_vulkan.cpp
@@ -209,7 +209,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/302_lambert_textured_cube_d3d12/302_lambert_textured_cube_d3d12.cpp
+++ b/projects/texture/302_lambert_textured_cube_d3d12/302_lambert_textured_cube_d3d12.cpp
@@ -210,7 +210,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/texture/302_lambert_textured_cube_metal/302_textured_cube_metal.cpp
+++ b/projects/texture/302_lambert_textured_cube_metal/302_textured_cube_metal.cpp
@@ -198,7 +198,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/302_lambert_textured_cube_vulkan/302_lambert_textured_cube_vulkan.cpp
+++ b/projects/texture/302_lambert_textured_cube_vulkan/302_lambert_textured_cube_vulkan.cpp
@@ -237,7 +237,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/303_phong_textured_cube_d3d12/303_phong_textured_cube_d3d12.cpp
+++ b/projects/texture/303_phong_textured_cube_d3d12/303_phong_textured_cube_d3d12.cpp
@@ -215,7 +215,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/texture/303_phong_textured_cube_metal/303_phong_textured_cube_metal.cpp
+++ b/projects/texture/303_phong_textured_cube_metal/303_phong_textured_cube_metal.cpp
@@ -203,7 +203,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/303_phong_textured_cube_vulkan/303_phong_textured_cube_vulkan.cpp
+++ b/projects/texture/303_phong_textured_cube_vulkan/303_phong_textured_cube_vulkan.cpp
@@ -251,7 +251,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/304_normal_map_d3d12/304_normal_map_d3d12.cpp
+++ b/projects/texture/304_normal_map_d3d12/304_normal_map_d3d12.cpp
@@ -222,7 +222,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/texture/304_normal_map_metal/304_normal_map_metal.cpp
+++ b/projects/texture/304_normal_map_metal/304_normal_map_metal.cpp
@@ -187,7 +187,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/304_normal_map_vulkan/304_normal_map_vulkan.cpp
+++ b/projects/texture/304_normal_map_vulkan/304_normal_map_vulkan.cpp
@@ -227,7 +227,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/305_normal_map_explorer_d3d12/305_normal_map_explorer_d3d12.cpp
+++ b/projects/texture/305_normal_map_explorer_d3d12/305_normal_map_explorer_d3d12.cpp
@@ -199,7 +199,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/texture/305_normal_map_explorer_metal/305_normal_map_explorer_metal.cpp
+++ b/projects/texture/305_normal_map_explorer_metal/305_normal_map_explorer_metal.cpp
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/305_normal_map_explorer_vulkan/305_normal_map_explorer_vulkan.cpp
+++ b/projects/texture/305_normal_map_explorer_vulkan/305_normal_map_explorer_vulkan.cpp
@@ -244,7 +244,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/306_parallax_occlusion_map_d3d12/306_parallax_occlusion_map_d3d12.cpp
+++ b/projects/texture/306_parallax_occlusion_map_d3d12/306_parallax_occlusion_map_d3d12.cpp
@@ -230,7 +230,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/texture/306_parallax_occlusion_map_metal/306_parallax_occlusion_map_metal.cpp
+++ b/projects/texture/306_parallax_occlusion_map_metal/306_parallax_occlusion_map_metal.cpp
@@ -191,7 +191,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/306_parallax_occlusion_map_vulkan/306_parallax_occlusion_map_vulkan.cpp
+++ b/projects/texture/306_parallax_occlusion_map_vulkan/306_parallax_occlusion_map_vulkan.cpp
@@ -232,7 +232,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/307_parallax_occlusion_map_explorer_d3d12/307_parallax_occlusion_map_explorer_d3d12.cpp
+++ b/projects/texture/307_parallax_occlusion_map_explorer_d3d12/307_parallax_occlusion_map_explorer_d3d12.cpp
@@ -200,7 +200,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/texture/307_parallax_occlusion_map_explorer_metal/307_parallax_occlusion_map_explorer_metal.cpp
+++ b/projects/texture/307_parallax_occlusion_map_explorer_metal/307_parallax_occlusion_map_explorer_metal.cpp
@@ -187,7 +187,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/307_parallax_occlusion_map_explorer_vulkan/307_parallax_occlusion_map_explorer_vulkan.cpp
+++ b/projects/texture/307_parallax_occlusion_map_explorer_vulkan/307_parallax_occlusion_map_explorer_vulkan.cpp
@@ -245,7 +245,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/308_normal_map_vs_pom_d3d12/308_normal_map_vs_pom_d3d12.cpp
+++ b/projects/texture/308_normal_map_vs_pom_d3d12/308_normal_map_vs_pom_d3d12.cpp
@@ -255,7 +255,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, GREX_DEFAULT_DSV_FORMAT)) {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;
     }

--- a/projects/texture/308_normal_map_vs_pom_metal/308_normal_map_vs_pom_metal.cpp
+++ b/projects/texture/308_normal_map_vs_pom_metal/308_normal_map_vs_pom_metal.cpp
@@ -257,7 +257,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetNativeWindow(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight(), 2, MTL::PixelFormatDepth32Float))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;

--- a/projects/texture/308_normal_map_vs_pom_vulkan/308_normal_map_vs_pom_vulkan.cpp
+++ b/projects/texture/308_normal_map_vs_pom_vulkan/308_normal_map_vs_pom_vulkan.cpp
@@ -337,7 +337,7 @@ int main(int argc, char** argv)
     // *************************************************************************
     // Swapchain
     // *************************************************************************
-    if (!InitSwapchain(renderer.get(), window->GetHWND(), window->GetWidth(), window->GetHeight()))
+    if (!InitSwapchain(renderer.get(), window->GetNativeWindowHandle(), window->GetWidth(), window->GetHeight()))
     {
         assert(false && "InitSwapchain failed");
         return EXIT_FAILURE;


### PR DESCRIPTION
Rename GetHWND() and GetNativeWindow() both to GetNativeWindowHandle()