### PR TITLE
Allow usage of DirectX Agility SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,44 @@ set(IMGUI_INC_DIR ${GREX_THIRD_PARTY_DIR}/imgui)
 add_subdirectory(${GREX_THIRD_PARTY_DIR}/meshoptimizer)
 
 # ------------------------------------------------------------------------------
+# Direct3D Agility SDK
+# ------------------------------------------------------------------------------
+if (GREX_AGILITY_SDK)
+
+	if (GREX_ENABLE_D3D12)
+		# Split the version into three parts (major.minor.patch)
+		string(REGEX MATCHALL "[0-9]+" VERSION_LIST "${GREX_AGILITY_SDK}")
+		list(LENGTH VERSION_LIST VERSION_LENGTH)
+
+		if (VERSION_LENGTH EQUAL 3)
+			list(GET VERSION_LIST 1 GREX_AGILITY_SDK_VERSION)
+		else()
+			message(FATAL_ERROR "Unknown DirectX Agility SDK Version ${GREX_AGILITY_SDK}. Should be <MAJOR.MINOR.PATCH> for the SDK version you wish to use")
+		endif()
+
+		# D3D12SDKPath needs to be a relative path from the binary to the D3D12Core.lib 
+		# you want to use
+		cmake_path(RELATIVE_PATH CMAKE_BINARY_DIR
+			BASE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+			OUTPUT_VARIABLE BIN_TO_BUILD_PATH)
+
+
+		# We need the extra leading ../ to deal with the sub-directory for the build format (Debug/Release/etc ...)
+		set(GREX_AGILITY_RELATIVE_SDK_PATH "../${BIN_TO_BUILD_PATH}/packages/Microsoft.Direct3D.D3D12.${GREX_AGILITY_SDK}/build/native/bin/x64")
+
+		# Output the results on the command line during build
+		message("Generating DirectX Agility SDK Export Symbols:")
+		message("  D3D12SDKVersion: ${GREX_AGILITY_SDK_VERSION}")
+		message("  D3D12SDKPath:    '${GREX_AGILITY_RELATIVE_SDK_PATH}'")
+		message("  NuGet PM:        NuGet\\Install-Package Microsoft.Direct3D.D3D12 -Version ${GREX_AGILITY_SDK}")
+		message("")
+
+	else()
+		message("GREX_AGILITY_SDK not supported for non D3D12 platforms")
+	endif()
+endif()
+
+# ------------------------------------------------------------------------------
 # Graphics experiments
 # ------------------------------------------------------------------------------
 add_subdirectory(projects)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,22 +213,53 @@ if (GREX_AGILITY_SDK)
 			message(FATAL_ERROR "Unknown DirectX Agility SDK Version ${GREX_AGILITY_SDK}. Should be <MAJOR.MINOR.PATCH> for the SDK version you wish to use")
 		endif()
 
+		set(GREX_AGILITY_SDK_NAME "Microsoft.Direct3D.D3D12")
+		set(GREX_AGILITY_SDK_PACKAGE_LOCATION ${CMAKE_BINARY_DIR}/packages/${GREX_AGILITY_SDK_NAME}.${GREX_AGILITY_SDK})
+
+		# Install nuget if we don't have it
+		set(GREX_NUGET_WEB_ADDRESS "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe")
+		set(GREX_NUGET_EXE ${CMAKE_BINARY_DIR}/bin/nuget.exe)
+
+		if (NOT EXISTS ${GREX_NUGET_EXE})
+			message(CHECK_START "Downloading nuget.exe")
+			file(DOWNLOAD ${GREX_NUGET_WEB_ADDRESS} ${GREX_NUGET_EXE} STATUS GREX_NUGET_DOWNLOAD_STATUS)
+
+			list(GET GREX_NUGET_DOWNLOAD_STATUS 0 GREX_NUGET_DOWNLOAD_ERROR_CODE)
+			list(GET GREX_NUGET_DOWNLOAD_STATUS 1 GREX_NUGET_DOWNLOAD_ERROR_STRING)
+			if (${GREX_NUGET_DOWNLOAD_ERROR_CODE} EQUAL 0)
+				message(CHECK_PASS "downloaded")
+			else()
+				file(REMOVE ${GREX_NUGET_EXE})
+				message(CHECK_FAIL "not downloaded")
+				message(FATAL_ERROR "'${GREX_NUGET_WEB_ADDRESS}' not found (${GREX_NUGET_DOWNLOAD_ERROR_CODE}) ${GREX_NUGET_DOWNLOAD_ERROR_STRING}")
+
+			endif()
+		endif()
+
+		# Install the DirectX Agility SDK if we don't have it
+		if (NOT EXISTS ${GREX_AGILITY_SDK_PACKAGE_LOCATION})
+			message(CHECK_START "Attempting to nuget install ${GREX_AGILITY_SDK_NAME} Ver: ${GREX_AGILITY_SDK}")
+			execute_process(
+				COMMAND "${GREX_NUGET_EXE}" install ${GREX_AGILITY_SDK_NAME} -Version ${GREX_AGILITY_SDK} -OutputDirectory ${CMAKE_BINARY_DIR}/packages
+				OUTPUT_QUIET
+				COMMAND_ERROR_IS_FATAL ANY) 
+			message(CHECK_PASS "installed")
+		endif()
+
 		# D3D12SDKPath needs to be a relative path from the binary to the D3D12Core.lib 
 		# you want to use
 		cmake_path(RELATIVE_PATH CMAKE_BINARY_DIR
 			BASE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
 			OUTPUT_VARIABLE BIN_TO_BUILD_PATH)
 
-
 		# We need the extra leading ../ to deal with the sub-directory for the build format (Debug/Release/etc ...)
-		set(GREX_AGILITY_RELATIVE_SDK_PATH "../${BIN_TO_BUILD_PATH}/packages/Microsoft.Direct3D.D3D12.${GREX_AGILITY_SDK}/build/native/bin/x64")
+		set(GREX_AGILITY_RELATIVE_SDK_PATH "../${BIN_TO_BUILD_PATH}/packages/${GREX_AGILITY_SDK_NAME}.${GREX_AGILITY_SDK}/build/native/bin/x64")
+		set(GREX_AGILITY_SDK_INCLUDES "${CMAKE_BINARY_DIR}/packages/${GREX_AGILITY_SDK_NAME}.${GREX_AGILITY_SDK}/build/native/include")
 
 		# Output the results on the command line during build
-		message("Generating DirectX Agility SDK Export Symbols:")
-		message("  D3D12SDKVersion: ${GREX_AGILITY_SDK_VERSION}")
-		message("  D3D12SDKPath:    '${GREX_AGILITY_RELATIVE_SDK_PATH}'")
-		message("  NuGet PM:        NuGet\\Install-Package Microsoft.Direct3D.D3D12 -Version ${GREX_AGILITY_SDK}")
-		message("")
+		message("   Generating DirectX Agility SDK Export Symbols:")
+		message("     D3D12SDKVersion: ${GREX_AGILITY_SDK_VERSION}")
+		message("     D3D12SDKPath:    '${GREX_AGILITY_RELATIVE_SDK_PATH}'")
 
 	else()
 		message("GREX_AGILITY_SDK not supported for non D3D12 platforms")

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ This will generate a solution for Visual Studio 2022 Professional in the `build-
 You can specify what Agility SDK you want to use with the command `-DGREX_AGILITY_SDK=X.Y.Z` where `X.Y.Z` is the version of the Agility SDK you want to use.
 
 Using this option will
-* Download nuget.exe to <BUILD DIRECTORY>/bin/nuget.exe
-* Download the desired Agility SDK to <BUILD DIRECTORY>/packages/... which is what the NuGet Package Manager would do for you in Visual Studio
-* Create a global variable that points to the include directory for the Agility SDK: ${GREX_AGILITY_SDK_INCLUDES}
+* Download nuget.exe to `BUILD DIRECTORY/bin/nuget.exe`
+* Download the desired Agility SDK to `BUILD DIRECTORY/packages/...` which is what the NuGet Package Manager would do for you in Visual Studio
+* Create a global variable that points to the include directory for the Agility SDK: `${GREX_AGILITY_SDK_INCLUDES}`
 
 It will also generate the following symbols that can then be used by individual projects
-* ${GREX_AGILITY_SDK_VERSION}
-* ${GREX_AGILITY_RELATIVE_SDK_PATH}
+* `${GREX_AGILITY_SDK_VERSION}`
+* `${GREX_AGILITY_RELATIVE_SDK_PATH}`
 
 You can enable the specified Agility SDK in your project's CMakeLists.txt file by adding the following to a project's CMakeLists.txt file
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ target_compile_definitions(
 
 Currently the `VS_PACKAGE_REFERENCES()` is not used to actually download/setup the NuGet file as it doesn't seem to work
 for C++ projects. However, the cmake process should print out the command you'll need to use in the Nuget Package
-Manager Console in Visual Studio (Tools -> NuGet Package Manager -> Package Manager Console).
+Manager Console in Visual Studio (*Tools -> NuGet Package Manager -> Package Manager Console*).
 
 ```
 NuGet\Install-Package Microsoft.Direct3D.D3D12 -Version X.Y.Z

--- a/README.md
+++ b/README.md
@@ -67,3 +67,34 @@ cmake -B build-vs2022
 ```
 This will generate a solution for Visual Studio 2022 Professional in the `build-vs2022` directory.
 
+### Direct3D Agility SDK
+
+You can specify what Agility SDK you want to use with the command `-DGREX_AGILITY_SDK=X.Y.Z` where `X.Y.Z` is the version of the Agility SDK you want to use. 
+
+It will generate the following symbols that can be used by individual projects
+* ${GREX_AGILITY_SDK_VERSION}
+* ${GREX_AGILITY_RELATIVE_SDK_PATH}
+
+You can enable the specified Agility SDK in your project by adding the following to a project's CMakeLists.txt file
+
+```
+target_compile_definitions(
+	MyTargetName
+	PUBLIC 
+		GREX_USE_AGILITY_SDK
+		GREX_AGILITY_SDK_VERSION=${GREX_AGILITY_SDK_VERSION}
+		GREX_AGILITY_SDK_PATH="${GREX_AGILITY_RELATIVE_SDK_PATH}"
+)
+```
+
+Currently the `VS_PACKAGE_REFERENCES()` is not used to actually download/setup the NuGet file as it doesn't seem to work
+for C++ projects. However, the cmake process should print out the command you'll need to use in the Nuget Package
+Manager Console in Visual Studio (Tools -> NuGet Package Manager -> Package Manager Console).
+
+```
+NuGet\Install-Package Microsoft.Direct3D.D3D12 -Version X.Y.Z
+```
+
+Which will download the package to the `build/packages/...` directory and setup your project to use it.
+
+

--- a/README.md
+++ b/README.md
@@ -69,32 +69,26 @@ This will generate a solution for Visual Studio 2022 Professional in the `build-
 
 ### Direct3D Agility SDK
 
-You can specify what Agility SDK you want to use with the command `-DGREX_AGILITY_SDK=X.Y.Z` where `X.Y.Z` is the version of the Agility SDK you want to use. 
+You can specify what Agility SDK you want to use with the command `-DGREX_AGILITY_SDK=X.Y.Z` where `X.Y.Z` is the version of the Agility SDK you want to use.
 
-It will generate the following symbols that can be used by individual projects
+Using this option will
+* Download nuget.exe to <BUILD DIRECTORY>/bin/nuget.exe
+* Download the desired Agility SDK to <BUILD DIRECTORY>/packages/... which is what the NuGet Package Manager would do for you in Visual Studio
+* Create a global variable that points to the include directory for the Agility SDK: ${GREX_AGILITY_SDK_INCLUDES}
+
+It will also generate the following symbols that can then be used by individual projects
 * ${GREX_AGILITY_SDK_VERSION}
 * ${GREX_AGILITY_RELATIVE_SDK_PATH}
 
-You can enable the specified Agility SDK in your project by adding the following to a project's CMakeLists.txt file
+You can enable the specified Agility SDK in your project's CMakeLists.txt file by adding the following to a project's CMakeLists.txt file
 
 ```
 target_compile_definitions(
-	MyTargetName
-	PUBLIC 
-		GREX_USE_AGILITY_SDK
-		GREX_AGILITY_SDK_VERSION=${GREX_AGILITY_SDK_VERSION}
-		GREX_AGILITY_SDK_PATH="${GREX_AGILITY_RELATIVE_SDK_PATH}"
+    ${PROJECT_NAME}
+    PUBLIC GREX_USE_AGILITY_SDK
+           GREX_AGILITY_SDK_VERSION=${GREX_AGILITY_SDK_VERSION}
+           GREX_AGILITY_SDK_PATH="${GREX_AGILITY_RELATIVE_SDK_PATH}"
 )
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${GREX_AGILITY_SDK_INCLUDES})
 ```
-
-Currently the `VS_PACKAGE_REFERENCES()` is not used to actually download/setup the NuGet file as it doesn't seem to work
-for C++ projects. However, the cmake process should print out the command you'll need to use in the Nuget Package
-Manager Console in Visual Studio (*Tools -> NuGet Package Manager -> Package Manager Console*).
-
-```
-NuGet\Install-Package Microsoft.Direct3D.D3D12 -Version X.Y.Z
-```
-
-Which will download the package to the `build/packages/...` directory and setup your project to use it.
-
-

--- a/projects/common/dx_renderer.cpp
+++ b/projects/common/dx_renderer.cpp
@@ -114,7 +114,6 @@ bool InitDx(DxRenderer* pRenderer, bool enableDebug)
 
             // Filter out remote and software adapters
             if (desc.Flags == DXGI_ADAPTER_FLAG_NONE)
-            //if (desc.Flags == DXGI_ADAPTER_FLAG_SOFTWARE)
             {
                 adapters.push_back(pEnumeratedAdapter);
             }

--- a/projects/common/dx_renderer.cpp
+++ b/projects/common/dx_renderer.cpp
@@ -1,5 +1,13 @@
 #include "dx_renderer.h"
 
+#if defined(GREX_USE_AGILITY_SDK)
+
+ extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = GREX_AGILITY_SDK_VERSION; }
+ extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = GREX_AGILITY_SDK_PATH; }
+ // extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = "../../third_party/DirectX-AgilitySDK/1.614.1/bin/x64"; }
+
+#endif
+
 bool     IsCompressed(DXGI_FORMAT fmt);
 bool     IsVideo(DXGI_FORMAT fmt);
 uint32_t BitsPerPixel(DXGI_FORMAT fmt);
@@ -106,6 +114,7 @@ bool InitDx(DxRenderer* pRenderer, bool enableDebug)
 
             // Filter out remote and software adapters
             if (desc.Flags == DXGI_ADAPTER_FLAG_NONE)
+            //if (desc.Flags == DXGI_ADAPTER_FLAG_SOFTWARE)
             {
                 adapters.push_back(pEnumeratedAdapter);
             }

--- a/projects/common/dx_renderer.h
+++ b/projects/common/dx_renderer.h
@@ -4,6 +4,8 @@
 
 #if defined(GREX_USE_D3DX12)
 #include "directx/d3dx12.h"
+#elif defined(GREX_USE_AGILITY_SDK)
+#include "d3dx12/d3dx12.h"
 #else
 #include <d3d12.h>
 #endif


### PR DESCRIPTION
If the `-DGREX_AGILITY_SDK="X.Y.Z"` command line option is used when generating a DirectX 12 solution, the specified Agility SDK will be downloaded and used by projects that ask for it.

Documentation on how to use it is at the bottom of the README.md file.