### PR TITLE
Add GLM_ENABLE_EXPERIMENTAL to fix Vulkan SDK build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # ------------------------------------------------------------------------------
 # Compile flags and definitions
 # ------------------------------------------------------------------------------
+add_definitions(-DGLM_ENABLE_EXPERIMENTAL)
+
 if (GREX_LINUX)
     add_definitions(-DGREX_LINUX)
 elseif (GREX_MACOS)


### PR DESCRIPTION
## Summary
- Adds  define globally in CMakeLists.txt
- Fixes build failures in Vulkan projects that use GLM experimental extensions (, ) from the Vulkan SDK bundled GLM
- Affected ~20 Vulkan projects across geometry, pbr, and texture categories

## Test plan
- [x] Full Debug build passes with zero errors (Windows 11, VS 2022, Vulkan SDK 1.4.313.2)
- [x] D3D12 and Vulkan projects verified to run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)