### PR TITLE
Add --screenshot option to all Metal projects

### DIFF
--- a/projects/common/mtl_renderer.cpp
+++ b/projects/common/mtl_renderer.cpp
@@ -1460,3 +1460,51 @@ uint32_t BitsPerElement(MTL::VertexFormat fmt)
             return 0;
     }
 }
+
+bool SaveMetalTextureAsPNG(MetalRenderer* pRenderer, MTL::CommandBuffer* pCommandBuffer, MTL::Texture* pTexture, const std::filesystem::path& absPath)
+{
+    const uint32_t width        = static_cast<uint32_t>(pTexture->width());
+    const uint32_t height       = static_cast<uint32_t>(pTexture->height());
+    const uint32_t bytesPerRow  = width * 4;
+    const size_t   bufferSize   = bytesPerRow * height;
+
+    // Create a shared buffer for CPU readback
+    NS::SharedPtr<MTL::Buffer> readbackBuffer = NS::TransferPtr(
+        pRenderer->Device->newBuffer(bufferSize, MTL::ResourceStorageModeShared));
+    if (!readbackBuffer)
+    {
+        GREX_LOG_ERROR("SaveMetalTextureAsPNG: failed to create readback buffer");
+        return false;
+    }
+
+    // Encode blit onto the existing command buffer (render + present already encoded)
+    MTL::BlitCommandEncoder* pBlit = pCommandBuffer->blitCommandEncoder();
+    pBlit->copyFromTexture(
+        pTexture,
+        0, 0,
+        MTL::Origin::Make(0, 0, 0),
+        MTL::Size::Make(width, height, 1),
+        readbackBuffer.get(),
+        0,
+        bytesPerRow,
+        bufferSize);
+    pBlit->endEncoding();
+
+    // Commit and wait — render, present, and blit all complete together
+    pCommandBuffer->commit();
+    pCommandBuffer->waitUntilCompleted();
+
+    // Texture is BGRA8 — swap B and R channels into an RGBA bitmap
+    BitmapRGBA8u bitmap(width, height);
+    const uint8_t* pSrc = static_cast<const uint8_t*>(readbackBuffer->contents());
+    uint8_t*       pDst = reinterpret_cast<uint8_t*>(bitmap.GetPixels());
+    for (uint32_t i = 0; i < width * height; ++i)
+    {
+        pDst[i * 4 + 0] = pSrc[i * 4 + 2]; // R <- B
+        pDst[i * 4 + 1] = pSrc[i * 4 + 1]; // G <- G
+        pDst[i * 4 + 2] = pSrc[i * 4 + 0]; // B <- R
+        pDst[i * 4 + 3] = pSrc[i * 4 + 3]; // A <- A
+    }
+
+    return BitmapRGBA8u::Save(absPath, &bitmap);
+}

--- a/projects/common/mtl_renderer.cpp
+++ b/projects/common/mtl_renderer.cpp
@@ -1494,7 +1494,8 @@ bool SaveMetalTextureAsPNG(MetalRenderer* pRenderer, MTL::CommandBuffer* pComman
     pCommandBuffer->commit();
     pCommandBuffer->waitUntilCompleted();
 
-    // Texture is BGRA8 — swap B and R channels into an RGBA bitmap
+    // Texture is BGRA8 — swap B and R channels into an RGBA bitmap.
+    // Force alpha to 255: swapchain alpha is shader-defined and often 0.
     BitmapRGBA8u bitmap(width, height);
     const uint8_t* pSrc = static_cast<const uint8_t*>(readbackBuffer->contents());
     uint8_t*       pDst = reinterpret_cast<uint8_t*>(bitmap.GetPixels());
@@ -1503,7 +1504,7 @@ bool SaveMetalTextureAsPNG(MetalRenderer* pRenderer, MTL::CommandBuffer* pComman
         pDst[i * 4 + 0] = pSrc[i * 4 + 2]; // R <- B
         pDst[i * 4 + 1] = pSrc[i * 4 + 1]; // G <- G
         pDst[i * 4 + 2] = pSrc[i * 4 + 0]; // B <- R
-        pDst[i * 4 + 3] = pSrc[i * 4 + 3]; // A <- A
+        pDst[i * 4 + 3] = 255;              // A <- 1 (swapchain alpha is meaningless)
     }
 
     return BitmapRGBA8u::Save(absPath, &bitmap);

--- a/projects/common/mtl_renderer.h
+++ b/projects/common/mtl_renderer.h
@@ -1,9 +1,12 @@
 #pragma once
 
 #include "config.h"
+#include "bitmap.h"
 
 #include <Metal/Metal.hpp>
 #include <QuartzCore/CAMetalLayer.hpp>
+
+#include <filesystem>
 
 #define GREX_DEFAULT_RTV_FORMAT MTL::PixelFormatBGRA8Unorm
 #define GREX_DEFAULT_DSV_FORMAT MTL::PixelFormatDepth32Float
@@ -168,3 +171,7 @@ NS::Error* CreateGraphicsPipeline2(
     MetalPipelineRenderState* pPipeline,
     MetalDepthStencilState*   pDepthStencilState,
     uint32_t*                 pOptionalStrides);
+
+// Encodes a blit readback onto pCommandBuffer, commits it, waits, then saves pTexture as PNG.
+// pCommandBuffer must not yet be committed. presentDrawable should be scheduled before calling.
+bool SaveMetalTextureAsPNG(MetalRenderer* pRenderer, MTL::CommandBuffer* pCommandBuffer, MTL::Texture* pTexture, const std::filesystem::path& absPath);

--- a/projects/common/window.cpp
+++ b/projects/common/window.cpp
@@ -782,6 +782,10 @@ GrexCommandLineArgs ParseCommandLineArgs(int argc, char** argv)
         {
             args.autoExitSeconds = atoi(argv[i + 1]);
         }
+        else if (strcmp(argv[i], "--screenshot") == 0)
+        {
+            args.screenshotPath = argv[i + 1];
+        }
     }
     return args;
 }

--- a/projects/common/window.cpp
+++ b/projects/common/window.cpp
@@ -785,6 +785,10 @@ GrexCommandLineArgs ParseCommandLineArgs(int argc, char** argv)
         else if (strcmp(argv[i], "--screenshot") == 0)
         {
             args.screenshotPath = argv[i + 1];
+            if (i + 2 < argc && isdigit(static_cast<unsigned char>(argv[i + 2][0])))
+            {
+                args.screenshotFrame = atoi(argv[i + 2]);
+            }
         }
     }
     return args;

--- a/projects/common/window.h
+++ b/projects/common/window.h
@@ -149,7 +149,8 @@ private:
 
 struct GrexCommandLineArgs
 {
-    int autoExitSeconds = -1; // -1 means no auto-exit
+    int         autoExitSeconds = -1; // -1 means no auto-exit
+    std::string screenshotPath  = ""; // empty means no screenshot
 };
 
 GrexCommandLineArgs ParseCommandLineArgs(int argc, char** argv);

--- a/projects/common/window.h
+++ b/projects/common/window.h
@@ -151,6 +151,7 @@ struct GrexCommandLineArgs
 {
     int         autoExitSeconds = -1; // -1 means no auto-exit
     std::string screenshotPath  = ""; // empty means no screenshot
+    int         screenshotFrame = -1; // -1 means first frame; N means wait for frame N (overrides auto-exit)
 };
 
 GrexCommandLineArgs ParseCommandLineArgs(int argc, char** argv);

--- a/projects/geometry/101_color_cube_metal/101_color_cube_metal.cpp
+++ b/projects/geometry/101_color_cube_metal/101_color_cube_metal.cpp
@@ -181,7 +181,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -231,15 +231,21 @@ int main(int argc, char** argv)
 
         pCommandBuffer->presentDrawable(pDrawable);
 
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/101_color_cube_metal/101_color_cube_metal.cpp
+++ b/projects/geometry/101_color_cube_metal/101_color_cube_metal.cpp
@@ -230,7 +230,16 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/101_color_cube_metal/CMakeLists.txt
+++ b/projects/geometry/101_color_cube_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     101_color_cube_metal
     101_color_cube_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/geometry/102_cornell_box_metal/102_cornell_box_metal.cpp
+++ b/projects/geometry/102_cornell_box_metal/102_cornell_box_metal.cpp
@@ -300,7 +300,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/102_cornell_box_metal/102_cornell_box_metal.cpp
+++ b/projects/geometry/102_cornell_box_metal/102_cornell_box_metal.cpp
@@ -230,7 +230,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -300,15 +300,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/102_cornell_box_metal/CMakeLists.txt
+++ b/projects/geometry/102_cornell_box_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     102_cornell_box_metal
     102_cornell_box_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/geometry/103_cone_metal/103_cone_metal.cpp
+++ b/projects/geometry/103_cone_metal/103_cone_metal.cpp
@@ -207,7 +207,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -275,15 +275,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/103_cone_metal/103_cone_metal.cpp
+++ b/projects/geometry/103_cone_metal/103_cone_metal.cpp
@@ -275,7 +275,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/103_cone_metal/CMakeLists.txt
+++ b/projects/geometry/103_cone_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     103_cone_metal
     103_cone_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/geometry/104_debug_tbn_metal/104_debug_tbn_metal.cpp
+++ b/projects/geometry/104_debug_tbn_metal/104_debug_tbn_metal.cpp
@@ -363,7 +363,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/104_debug_tbn_metal/104_debug_tbn_metal.cpp
+++ b/projects/geometry/104_debug_tbn_metal/104_debug_tbn_metal.cpp
@@ -263,7 +263,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -363,15 +363,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/104_debug_tbn_metal/CMakeLists.txt
+++ b/projects/geometry/104_debug_tbn_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     104_debug_tbn_metal
     104_debug_tbn_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/geometry/110_mesh_shader_triangle_metal/110_mesh_shader_triangle_metal.cpp
+++ b/projects/geometry/110_mesh_shader_triangle_metal/110_mesh_shader_triangle_metal.cpp
@@ -222,7 +222,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/110_mesh_shader_triangle_metal/110_mesh_shader_triangle_metal.cpp
+++ b/projects/geometry/110_mesh_shader_triangle_metal/110_mesh_shader_triangle_metal.cpp
@@ -195,7 +195,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -222,15 +222,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/110_mesh_shader_triangle_metal/CMakeLists.txt
+++ b/projects/geometry/110_mesh_shader_triangle_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     110_mesh_shader_triangle_metal
     110_mesh_shader_triangle_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/geometry/111_mesh_shader_meshlets_metal/111_mesh_shader_meshlets_metal.cpp
+++ b/projects/geometry/111_mesh_shader_meshlets_metal/111_mesh_shader_meshlets_metal.cpp
@@ -271,7 +271,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -318,15 +318,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/111_mesh_shader_meshlets_metal/111_mesh_shader_meshlets_metal.cpp
+++ b/projects/geometry/111_mesh_shader_meshlets_metal/111_mesh_shader_meshlets_metal.cpp
@@ -318,7 +318,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/111_mesh_shader_meshlets_metal/CMakeLists.txt
+++ b/projects/geometry/111_mesh_shader_meshlets_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     111_mesh_shader_meshlets_metal
     111_mesh_shader_meshlets_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/geometry/112_mesh_shader_amplification_metal/112_mesh_shader_amplification_metal.cpp
+++ b/projects/geometry/112_mesh_shader_amplification_metal/112_mesh_shader_amplification_metal.cpp
@@ -323,7 +323,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/112_mesh_shader_amplification_metal/112_mesh_shader_amplification_metal.cpp
+++ b/projects/geometry/112_mesh_shader_amplification_metal/112_mesh_shader_amplification_metal.cpp
@@ -275,7 +275,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -323,15 +323,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/112_mesh_shader_amplification_metal/CMakeLists.txt
+++ b/projects/geometry/112_mesh_shader_amplification_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     112_mesh_shader_amplification_metal
     112_mesh_shader_amplification_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/geometry/113_mesh_shader_instancing_metal/113_mesh_shader_instancing_metal.cpp
+++ b/projects/geometry/113_mesh_shader_instancing_metal/113_mesh_shader_instancing_metal.cpp
@@ -388,7 +388,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/113_mesh_shader_instancing_metal/113_mesh_shader_instancing_metal.cpp
+++ b/projects/geometry/113_mesh_shader_instancing_metal/113_mesh_shader_instancing_metal.cpp
@@ -291,7 +291,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -388,15 +388,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/113_mesh_shader_instancing_metal/CMakeLists.txt
+++ b/projects/geometry/113_mesh_shader_instancing_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     113_mesh_shader_instancing_metal
     113_mesh_shader_instancing_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/geometry/114_mesh_shader_culling_metal/114_mesh_shader_culling_metal.cpp
+++ b/projects/geometry/114_mesh_shader_culling_metal/114_mesh_shader_culling_metal.cpp
@@ -600,7 +600,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/114_mesh_shader_culling_metal/114_mesh_shader_culling_metal.cpp
+++ b/projects/geometry/114_mesh_shader_culling_metal/114_mesh_shader_culling_metal.cpp
@@ -426,7 +426,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -600,15 +600,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/114_mesh_shader_culling_metal/CMakeLists.txt
+++ b/projects/geometry/114_mesh_shader_culling_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     114_mesh_shader_culling_metal
     114_mesh_shader_culling_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/geometry/115_mesh_shader_lod_metal/115_mesh_shader_lod_metal.cpp
+++ b/projects/geometry/115_mesh_shader_lod_metal/115_mesh_shader_lod_metal.cpp
@@ -614,7 +614,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/115_mesh_shader_lod_metal/115_mesh_shader_lod_metal.cpp
+++ b/projects/geometry/115_mesh_shader_lod_metal/115_mesh_shader_lod_metal.cpp
@@ -454,7 +454,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -614,15 +614,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/115_mesh_shader_lod_metal/CMakeLists.txt
+++ b/projects/geometry/115_mesh_shader_lod_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     115_mesh_shader_lod_metal
     115_mesh_shader_lod_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/geometry/116_mesh_shader_calc_lod_metal/116_mesh_shader_calc_lod_metal.cpp
+++ b/projects/geometry/116_mesh_shader_calc_lod_metal/116_mesh_shader_calc_lod_metal.cpp
@@ -461,7 +461,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -627,15 +627,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/116_mesh_shader_calc_lod_metal/116_mesh_shader_calc_lod_metal.cpp
+++ b/projects/geometry/116_mesh_shader_calc_lod_metal/116_mesh_shader_calc_lod_metal.cpp
@@ -627,7 +627,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/116_mesh_shader_calc_lod_metal/CMakeLists.txt
+++ b/projects/geometry/116_mesh_shader_calc_lod_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     116_mesh_shader_calc_lod_metal
     116_mesh_shader_calc_lod_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/geometry/117_mesh_shader_cull_lod_metal/117_mesh_shader_cull_lod_metal.cpp
+++ b/projects/geometry/117_mesh_shader_cull_lod_metal/117_mesh_shader_cull_lod_metal.cpp
@@ -741,7 +741,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/117_mesh_shader_cull_lod_metal/117_mesh_shader_cull_lod_metal.cpp
+++ b/projects/geometry/117_mesh_shader_cull_lod_metal/117_mesh_shader_cull_lod_metal.cpp
@@ -545,7 +545,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -741,15 +741,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/117_mesh_shader_cull_lod_metal/CMakeLists.txt
+++ b/projects/geometry/117_mesh_shader_cull_lod_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     ${PROJECT_NAME} 
     ${PROJECT_NAME}.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/geometry/118_mesh_shader_vertex_attrs_metal/118_mesh_shader_vertex_attrs_metal.cpp
+++ b/projects/geometry/118_mesh_shader_vertex_attrs_metal/118_mesh_shader_vertex_attrs_metal.cpp
@@ -429,7 +429,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/geometry/118_mesh_shader_vertex_attrs_metal/118_mesh_shader_vertex_attrs_metal.cpp
+++ b/projects/geometry/118_mesh_shader_vertex_attrs_metal/118_mesh_shader_vertex_attrs_metal.cpp
@@ -332,7 +332,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -429,15 +429,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/geometry/118_mesh_shader_vertex_attrs_metal/CMakeLists.txt
+++ b/projects/geometry/118_mesh_shader_vertex_attrs_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     ${PROJECT_NAME} 
     ${PROJECT_NAME}.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h

--- a/projects/io/401_gltf_basic_geo_metal/401_gltf_basic_geo_metal.cpp
+++ b/projects/io/401_gltf_basic_geo_metal/401_gltf_basic_geo_metal.cpp
@@ -352,7 +352,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/io/401_gltf_basic_geo_metal/401_gltf_basic_geo_metal.cpp
+++ b/projects/io/401_gltf_basic_geo_metal/401_gltf_basic_geo_metal.cpp
@@ -295,7 +295,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -352,15 +352,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/io/402_gltf_basic_texture_metal/402_gltf_basic_texture_metal.cpp
+++ b/projects/io/402_gltf_basic_texture_metal/402_gltf_basic_texture_metal.cpp
@@ -352,7 +352,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/io/402_gltf_basic_texture_metal/402_gltf_basic_texture_metal.cpp
+++ b/projects/io/402_gltf_basic_texture_metal/402_gltf_basic_texture_metal.cpp
@@ -295,7 +295,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -352,15 +352,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/io/403_gltf_basic_material_metal/403_gltf_basic_material_metal.cpp
+++ b/projects/io/403_gltf_basic_material_metal/403_gltf_basic_material_metal.cpp
@@ -352,7 +352,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/io/403_gltf_basic_material_metal/403_gltf_basic_material_metal.cpp
+++ b/projects/io/403_gltf_basic_material_metal/403_gltf_basic_material_metal.cpp
@@ -295,7 +295,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -352,15 +352,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/io/404_gltf_basic_material_texture_metal/404_gltf_basic_material_texture_metal.cpp
+++ b/projects/io/404_gltf_basic_material_texture_metal/404_gltf_basic_material_texture_metal.cpp
@@ -356,7 +356,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/io/404_gltf_basic_material_texture_metal/404_gltf_basic_material_texture_metal.cpp
+++ b/projects/io/404_gltf_basic_material_texture_metal/404_gltf_basic_material_texture_metal.cpp
@@ -299,7 +299,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -356,15 +356,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/pbr/201_pbr_spheres_metal/201_pbr_spheres_metal.cpp
+++ b/projects/pbr/201_pbr_spheres_metal/201_pbr_spheres_metal.cpp
@@ -314,7 +314,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -502,15 +502,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/pbr/201_pbr_spheres_metal/201_pbr_spheres_metal.cpp
+++ b/projects/pbr/201_pbr_spheres_metal/201_pbr_spheres_metal.cpp
@@ -502,7 +502,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/pbr/202_pbr_camera_metal/202_pbr_camera_metal.cpp
+++ b/projects/pbr/202_pbr_camera_metal/202_pbr_camera_metal.cpp
@@ -604,7 +604,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/pbr/202_pbr_camera_metal/202_pbr_camera_metal.cpp
+++ b/projects/pbr/202_pbr_camera_metal/202_pbr_camera_metal.cpp
@@ -422,7 +422,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -604,15 +604,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/pbr/203_pbr_align_metal/203_pbr_align_metal.cpp
+++ b/projects/pbr/203_pbr_align_metal/203_pbr_align_metal.cpp
@@ -572,7 +572,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/pbr/203_pbr_align_metal/203_pbr_align_metal.cpp
+++ b/projects/pbr/203_pbr_align_metal/203_pbr_align_metal.cpp
@@ -314,7 +314,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -572,15 +572,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/pbr/251_pbr_explorer_metal/251_pbr_explorer_metal.cpp
+++ b/projects/pbr/251_pbr_explorer_metal/251_pbr_explorer_metal.cpp
@@ -464,7 +464,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -1046,15 +1046,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/pbr/251_pbr_explorer_metal/251_pbr_explorer_metal.cpp
+++ b/projects/pbr/251_pbr_explorer_metal/251_pbr_explorer_metal.cpp
@@ -1046,7 +1046,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/pbr/252_pbr_material_properties_metal/252_pbr_material_properties_metal.cpp
+++ b/projects/pbr/252_pbr_material_properties_metal/252_pbr_material_properties_metal.cpp
@@ -675,7 +675,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/pbr/252_pbr_material_properties_metal/252_pbr_material_properties_metal.cpp
+++ b/projects/pbr/252_pbr_material_properties_metal/252_pbr_material_properties_metal.cpp
@@ -398,7 +398,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -675,15 +675,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/pbr/253_pbr_material_textures_metal/253_pbr_material_textures_metal.cpp
+++ b/projects/pbr/253_pbr_material_textures_metal/253_pbr_material_textures_metal.cpp
@@ -1192,7 +1192,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/pbr/253_pbr_material_textures_metal/253_pbr_material_textures_metal.cpp
+++ b/projects/pbr/253_pbr_material_textures_metal/253_pbr_material_textures_metal.cpp
@@ -472,7 +472,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -1192,15 +1192,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/raytracing/000_raygen_uv_metal/000_raygen_uv_metal.cpp
+++ b/projects/raytracing/000_raygen_uv_metal/000_raygen_uv_metal.cpp
@@ -245,7 +245,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/raytracing/000_raygen_uv_metal/000_raygen_uv_metal.cpp
+++ b/projects/raytracing/000_raygen_uv_metal/000_raygen_uv_metal.cpp
@@ -208,7 +208,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -245,15 +245,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/raytracing/000_raygen_uv_metal/CMakeLists.txt
+++ b/projects/raytracing/000_raygen_uv_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     000_raygen_uv_metal
     000_raygen_uv_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h
@@ -23,6 +25,7 @@ target_include_directories(
     PUBLIC ${GREX_PROJECTS_COMMON_DIR}
            ${GREX_THIRD_PARTY_DIR}/glm
            ${GREX_THIRD_PARTY_DIR}/metal-cpp
+    ${GREX_THIRD_PARTY_DIR}/stb
 )
 
 FIND_LIBRARY(FOUNDATION_LIBRARY Foundation)

--- a/projects/raytracing/001_raytracing_basic_metal/001_raytracing_basic_metal.cpp
+++ b/projects/raytracing/001_raytracing_basic_metal/001_raytracing_basic_metal.cpp
@@ -274,7 +274,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -324,15 +324,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/raytracing/001_raytracing_basic_metal/001_raytracing_basic_metal.cpp
+++ b/projects/raytracing/001_raytracing_basic_metal/001_raytracing_basic_metal.cpp
@@ -324,7 +324,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/raytracing/001_raytracing_basic_metal/CMakeLists.txt
+++ b/projects/raytracing/001_raytracing_basic_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     001_raytracing_basic_metal
     001_raytracing_basic_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h
@@ -23,6 +25,7 @@ target_include_directories(
     PUBLIC ${GREX_PROJECTS_COMMON_DIR}
            ${GREX_THIRD_PARTY_DIR}/glm
            ${GREX_THIRD_PARTY_DIR}/metal-cpp
+    ${GREX_THIRD_PARTY_DIR}/stb
 )
 
 FIND_LIBRARY(FOUNDATION_LIBRARY Foundation)

--- a/projects/raytracing/002_basic_procedural_metal/002_basic_procedural_metal.cpp
+++ b/projects/raytracing/002_basic_procedural_metal/002_basic_procedural_metal.cpp
@@ -372,7 +372,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -423,15 +423,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/raytracing/002_basic_procedural_metal/002_basic_procedural_metal.cpp
+++ b/projects/raytracing/002_basic_procedural_metal/002_basic_procedural_metal.cpp
@@ -423,7 +423,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/raytracing/002_basic_procedural_metal/CMakeLists.txt
+++ b/projects/raytracing/002_basic_procedural_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     002_basic_procedural_metal
     002_basic_procedural_metal.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h
@@ -23,6 +25,7 @@ target_include_directories(
     PUBLIC ${GREX_PROJECTS_COMMON_DIR}
            ${GREX_THIRD_PARTY_DIR}/glm
            ${GREX_THIRD_PARTY_DIR}/metal-cpp
+    ${GREX_THIRD_PARTY_DIR}/stb
 )
 
 FIND_LIBRARY(FOUNDATION_LIBRARY Foundation)

--- a/projects/raytracing/003_sphereflake_metal/003_sphereflake_metal.cpp
+++ b/projects/raytracing/003_sphereflake_metal/003_sphereflake_metal.cpp
@@ -527,7 +527,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/raytracing/003_sphereflake_metal/003_sphereflake_metal.cpp
+++ b/projects/raytracing/003_sphereflake_metal/003_sphereflake_metal.cpp
@@ -468,7 +468,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -527,15 +527,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/raytracing/003_sphereflake_metal/CMakeLists.txt
+++ b/projects/raytracing/003_sphereflake_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     ${PROJECT_NAME}
     ${PROJECT_NAME}.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h
@@ -25,6 +27,7 @@ target_include_directories(
     PUBLIC ${GREX_PROJECTS_COMMON_DIR}
            ${GREX_THIRD_PARTY_DIR}/glm
            ${GREX_THIRD_PARTY_DIR}/metal-cpp
+    ${GREX_THIRD_PARTY_DIR}/stb
 )
 
 FIND_LIBRARY(FOUNDATION_LIBRARY Foundation)

--- a/projects/raytracing/004_basic_reflection_metal/004_basic_reflection_metal.cpp
+++ b/projects/raytracing/004_basic_reflection_metal/004_basic_reflection_metal.cpp
@@ -544,7 +544,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -607,15 +607,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/raytracing/004_basic_reflection_metal/004_basic_reflection_metal.cpp
+++ b/projects/raytracing/004_basic_reflection_metal/004_basic_reflection_metal.cpp
@@ -607,7 +607,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/raytracing/004_basic_reflection_metal/CMakeLists.txt
+++ b/projects/raytracing/004_basic_reflection_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     ${PROJECT_NAME}
     ${PROJECT_NAME}.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h
@@ -25,6 +27,7 @@ target_include_directories(
     PUBLIC ${GREX_PROJECTS_COMMON_DIR}
            ${GREX_THIRD_PARTY_DIR}/glm
            ${GREX_THIRD_PARTY_DIR}/metal-cpp
+    ${GREX_THIRD_PARTY_DIR}/stb
 )
 
 FIND_LIBRARY(FOUNDATION_LIBRARY Foundation)

--- a/projects/raytracing/005_basic_shadow_metal/005_basic_shadow_metal.cpp
+++ b/projects/raytracing/005_basic_shadow_metal/005_basic_shadow_metal.cpp
@@ -668,7 +668,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/raytracing/005_basic_shadow_metal/005_basic_shadow_metal.cpp
+++ b/projects/raytracing/005_basic_shadow_metal/005_basic_shadow_metal.cpp
@@ -605,7 +605,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -668,15 +668,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/raytracing/005_basic_shadow_metal/CMakeLists.txt
+++ b/projects/raytracing/005_basic_shadow_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     ${PROJECT_NAME}
     ${PROJECT_NAME}.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h
@@ -25,6 +27,7 @@ target_include_directories(
     PUBLIC ${GREX_PROJECTS_COMMON_DIR}
            ${GREX_THIRD_PARTY_DIR}/glm
            ${GREX_THIRD_PARTY_DIR}/metal-cpp
+    ${GREX_THIRD_PARTY_DIR}/stb
 )
 
 FIND_LIBRARY(FOUNDATION_LIBRARY Foundation)

--- a/projects/raytracing/006_basic_shadow_dynamic_metal/006_basic_shadow_dynamic_metal.cpp
+++ b/projects/raytracing/006_basic_shadow_dynamic_metal/006_basic_shadow_dynamic_metal.cpp
@@ -679,7 +679,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/raytracing/006_basic_shadow_dynamic_metal/006_basic_shadow_dynamic_metal.cpp
+++ b/projects/raytracing/006_basic_shadow_dynamic_metal/006_basic_shadow_dynamic_metal.cpp
@@ -606,7 +606,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -679,15 +679,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/raytracing/006_basic_shadow_dynamic_metal/CMakeLists.txt
+++ b/projects/raytracing/006_basic_shadow_dynamic_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     ${PROJECT_NAME}
     ${PROJECT_NAME}.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h
@@ -25,6 +27,7 @@ target_include_directories(
     PUBLIC ${GREX_PROJECTS_COMMON_DIR}
            ${GREX_THIRD_PARTY_DIR}/glm
            ${GREX_THIRD_PARTY_DIR}/metal-cpp
+    ${GREX_THIRD_PARTY_DIR}/stb
 )
 
 FIND_LIBRARY(FOUNDATION_LIBRARY Foundation)

--- a/projects/raytracing/021_raytracing_triangles_metal/021_raytracing_triangles_metal.cpp
+++ b/projects/raytracing/021_raytracing_triangles_metal/021_raytracing_triangles_metal.cpp
@@ -221,7 +221,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -281,15 +281,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/raytracing/021_raytracing_triangles_metal/021_raytracing_triangles_metal.cpp
+++ b/projects/raytracing/021_raytracing_triangles_metal/021_raytracing_triangles_metal.cpp
@@ -281,7 +281,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/raytracing/021_raytracing_triangles_metal/CMakeLists.txt
+++ b/projects/raytracing/021_raytracing_triangles_metal/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(
     ${PROJECT_NAME}
     ${PROJECT_NAME}.cpp
     ${GREX_PROJECTS_COMMON_DIR}/config.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.h
+    ${GREX_PROJECTS_COMMON_DIR}/bitmap.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.h
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer.cpp
     ${GREX_PROJECTS_COMMON_DIR}/mtl_renderer_utils.h
@@ -26,6 +28,7 @@ target_include_directories(
            ${GREX_THIRD_PARTY_DIR}/glm
            ${GREX_THIRD_PARTY_DIR}/tinyobjloader
            ${GREX_THIRD_PARTY_DIR}/metal-cpp
+    ${GREX_THIRD_PARTY_DIR}/stb
 )
 
 FIND_LIBRARY(FOUNDATION_LIBRARY Foundation)

--- a/projects/raytracing/030_raytracing_path_trace_metal/030_raytracing_path_trace_metal.cpp
+++ b/projects/raytracing/030_raytracing_path_trace_metal/030_raytracing_path_trace_metal.cpp
@@ -393,7 +393,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -553,16 +553,22 @@ int main(int argc, char** argv)
         }
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
         pCommandBuffer->waitUntilCompleted();
+
+        ++frameIndex;
 
         // Update sample count
         if (sampleCount < gMaxSamples)

--- a/projects/raytracing/030_raytracing_path_trace_metal/030_raytracing_path_trace_metal.cpp
+++ b/projects/raytracing/030_raytracing_path_trace_metal/030_raytracing_path_trace_metal.cpp
@@ -553,7 +553,15 @@ int main(int argc, char** argv)
         }
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
         pCommandBuffer->waitUntilCompleted();
 
         // Update sample count

--- a/projects/raytracing/031_raytracing_path_trace_pbr_metal/031_raytracing_path_trace_pbr_metal.cpp
+++ b/projects/raytracing/031_raytracing_path_trace_pbr_metal/031_raytracing_path_trace_pbr_metal.cpp
@@ -682,7 +682,15 @@ int main(int argc, char** argv)
         }
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
         pCommandBuffer->waitUntilCompleted();
 
         // Update sample count

--- a/projects/raytracing/031_raytracing_path_trace_pbr_metal/031_raytracing_path_trace_pbr_metal.cpp
+++ b/projects/raytracing/031_raytracing_path_trace_pbr_metal/031_raytracing_path_trace_pbr_metal.cpp
@@ -482,7 +482,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -682,16 +682,22 @@ int main(int argc, char** argv)
         }
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
         pCommandBuffer->waitUntilCompleted();
+
+        ++frameIndex;
 
         // Update sample count
         if (sampleCount < gMaxSamples)

--- a/projects/texture/301_textured_cube_metal/301_textured_cube_metal.cpp
+++ b/projects/texture/301_textured_cube_metal/301_textured_cube_metal.cpp
@@ -193,7 +193,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -243,15 +243,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/texture/301_textured_cube_metal/301_textured_cube_metal.cpp
+++ b/projects/texture/301_textured_cube_metal/301_textured_cube_metal.cpp
@@ -243,7 +243,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/texture/302_lambert_textured_cube_metal/302_textured_cube_metal.cpp
+++ b/projects/texture/302_lambert_textured_cube_metal/302_textured_cube_metal.cpp
@@ -270,7 +270,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/texture/302_lambert_textured_cube_metal/302_textured_cube_metal.cpp
+++ b/projects/texture/302_lambert_textured_cube_metal/302_textured_cube_metal.cpp
@@ -216,7 +216,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -270,15 +270,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/texture/303_phong_textured_cube_metal/303_phong_textured_cube_metal.cpp
+++ b/projects/texture/303_phong_textured_cube_metal/303_phong_textured_cube_metal.cpp
@@ -277,7 +277,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/texture/303_phong_textured_cube_metal/303_phong_textured_cube_metal.cpp
+++ b/projects/texture/303_phong_textured_cube_metal/303_phong_textured_cube_metal.cpp
@@ -221,7 +221,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -277,15 +277,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/texture/304_normal_map_metal/304_normal_map_metal.cpp
+++ b/projects/texture/304_normal_map_metal/304_normal_map_metal.cpp
@@ -279,7 +279,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/texture/304_normal_map_metal/304_normal_map_metal.cpp
+++ b/projects/texture/304_normal_map_metal/304_normal_map_metal.cpp
@@ -207,7 +207,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -279,15 +279,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/texture/305_normal_map_explorer_metal/305_normal_map_explorer_metal.cpp
+++ b/projects/texture/305_normal_map_explorer_metal/305_normal_map_explorer_metal.cpp
@@ -349,7 +349,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/texture/305_normal_map_explorer_metal/305_normal_map_explorer_metal.cpp
+++ b/projects/texture/305_normal_map_explorer_metal/305_normal_map_explorer_metal.cpp
@@ -220,7 +220,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -349,15 +349,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/texture/306_parallax_occlusion_map_metal/306_parallax_occlusion_map_metal.cpp
+++ b/projects/texture/306_parallax_occlusion_map_metal/306_parallax_occlusion_map_metal.cpp
@@ -209,7 +209,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -282,15 +282,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/texture/306_parallax_occlusion_map_metal/306_parallax_occlusion_map_metal.cpp
+++ b/projects/texture/306_parallax_occlusion_map_metal/306_parallax_occlusion_map_metal.cpp
@@ -282,7 +282,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/texture/307_parallax_occlusion_map_explorer_metal/307_parallax_occlusion_map_explorer_metal.cpp
+++ b/projects/texture/307_parallax_occlusion_map_explorer_metal/307_parallax_occlusion_map_explorer_metal.cpp
@@ -351,7 +351,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;

--- a/projects/texture/307_parallax_occlusion_map_explorer_metal/307_parallax_occlusion_map_explorer_metal.cpp
+++ b/projects/texture/307_parallax_occlusion_map_explorer_metal/307_parallax_occlusion_map_explorer_metal.cpp
@@ -221,7 +221,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -351,15 +351,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/texture/308_normal_map_vs_pom_metal/308_normal_map_vs_pom_metal.cpp
+++ b/projects/texture/308_normal_map_vs_pom_metal/308_normal_map_vs_pom_metal.cpp
@@ -298,7 +298,7 @@ int main(int argc, char** argv)
 
     while (window->PollEvents())
     {
-        if (args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
+        if (args.screenshotFrame < 0 && args.autoExitSeconds >= 0 && window->GetElapsedSeconds() >= args.autoExitSeconds)
         {
             break;
         }
@@ -474,15 +474,21 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        if (!args.screenshotPath.empty())
+        if (!args.screenshotPath.empty() && (args.screenshotFrame < 0 || (int)frameIndex == args.screenshotFrame))
         {
             SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
             args.screenshotPath.clear();
+            if (args.screenshotFrame >= 0)
+            {
+                break;
+            }
         }
         else
         {
             pCommandBuffer->commit();
         }
+
+        ++frameIndex;
     }
 
     return 0;

--- a/projects/texture/308_normal_map_vs_pom_metal/308_normal_map_vs_pom_metal.cpp
+++ b/projects/texture/308_normal_map_vs_pom_metal/308_normal_map_vs_pom_metal.cpp
@@ -474,7 +474,15 @@ int main(int argc, char** argv)
         pRenderEncoder->endEncoding();
 
         pCommandBuffer->presentDrawable(pDrawable);
-        pCommandBuffer->commit();
+        if (!args.screenshotPath.empty())
+        {
+            SaveMetalTextureAsPNG(renderer.get(), pCommandBuffer, pDrawable->texture(), args.screenshotPath);
+            args.screenshotPath.clear();
+        }
+        else
+        {
+            pCommandBuffer->commit();
+        }
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- Add `SaveMetalTextureAsPNG()` helper to `mtl_renderer.h/cpp` — encodes a blit readback onto the existing command buffer, commits+waits, swaps BGRA→RGBA (forcing alpha=255), and saves as PNG
- Add `--screenshot <path> [frame]` to `GrexCommandLineArgs` / `ParseCommandLineArgs` in `window.h/cpp`
  - Without frame count: screenshot taken on the first frame
  - With frame count N: waits for frame N, takes screenshot, then exits (overrides `--auto-exit`)
- Apply to all 41 Metal projects
- Fix `++frameIndex` missing from all Metal render loops
- Fix alpha=0 in screenshots caused by shaders that don't write alpha (PBR, some raytracing)

## Test plan
- [ ] `./bin/101_color_cube_metal --screenshot out.png --auto-exit 1` — exits after 1s with correct PNG
- [ ] `./bin/030_raytracing_path_trace_metal --screenshot out.png 100` — exits after frame 100 with converged path trace
- [ ] `./bin/031_raytracing_path_trace_pbr_metal --screenshot out.png 100` — same
- [ ] All 41 Metal binaries produce correct PNG output (tested via `--auto-exit 1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)